### PR TITLE
deprecate python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
 language: python
 
 python:
-  - 2.6
   - 2.7
   - 3.4
   - 3.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ environment:
 
     # Python names come from: https://www.appveyor.com/docs/build-environment/#python
 
-    # Python 2.6 does not work any more.  It gets errors installing arrow.
-    # I'm not going to take the time right now to figure out why.
-
     - PYTHON: "C://Python27"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"

--- a/b2sdk/b2http.py
+++ b/b2sdk/b2http.py
@@ -216,13 +216,10 @@ class ClockSkewHook(HttpCallback):
         # Get the local time
         local_time = arrow.utcnow()
 
-        # Check the difference.  The timedelta.total_seconds() method is not available
-        # in Python 2.6, so we'll compute it using the formula from the Python docs.
+        # Check the difference.
         max_allowed = 10 * 60  # ten minutes, in seconds
         skew = local_time - server_time
-        skew_seconds = int(
-            (skew.microseconds + (skew.seconds + skew.days * 24 * 3600) * 1000000) / 1000000
-        )
+        skew_seconds = skew.total_seconds()
         if max_allowed < abs(skew_seconds):
             raise ClockSkew(skew_seconds)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-arrow>=0.8.0,<0.12.1
+arrow>=0.8.0,<0.13.1
 logfury>=0.1.2
 requests>=2.9.1
 six>=1.10

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
Python 2.6 has been EOL since 29-10-2013

Adding equivalent changes from https://github.com/Backblaze/B2_Command_Line_Tool/pull/558