### PR TITLE
Fix transferer crashing on empty file download attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ b2sdk>=0.0.0,<1.0.0
 
 # Release History
 
+## 0.1.6 (not released yet)
+
+Changes:
+
+* Fix transferer crashing on empty file download attempt
+
+
 ## 0.1.4 (2019-04-04)
 
 Initial official release of SDK as a separate package (until now it was a part of B2 CLI)

--- a/b2sdk/transferer/abstract.py
+++ b/b2sdk/transferer/abstract.py
@@ -48,7 +48,7 @@ class AbstractDownloader(object):
         """
         raw_range_header = response.request.headers.get('Range')  # 'bytes 0-11'
         if raw_range_header is None:
-            return Range(0, metadata.content_length - 1)
+            return Range(0, 0 if metadata.content_length == 0 else metadata.content_length - 1)
         return Range.from_header(raw_range_header)
 
     @abstractmethod

--- a/test/test_bucket.py
+++ b/test/test_bucket.py
@@ -578,11 +578,20 @@ class DownloadTests(object):
             self.assertEqual(contents, expected_contents)
 
 
-class TestDownloadDefault(DownloadTests, TestCaseWithBucket):
+class EmptyFileDownloadScenarioMixin(object):
+    """ use with DownloadTests, but not for TestDownloadParallel as it does not like empty files """
+
+    def test_download_by_name_empty_file(self):
+        self.file_info = self.bucket.upload_bytes(six.b(''), 'empty')
+        self.bucket.download_file_by_name('empty', self.download_dest, self.progress_listener)
+        self._verify('')
+
+
+class TestDownloadDefault(DownloadTests, EmptyFileDownloadScenarioMixin, TestCaseWithBucket):
     pass
 
 
-class TestDownloadSimple(DownloadTests, TestCaseWithBucket):
+class TestDownloadSimple(DownloadTests, EmptyFileDownloadScenarioMixin, TestCaseWithBucket):
     def setUp(self):
         super(TestDownloadSimple, self).setUp()
         self.bucket.api.transferer.strategies = [SimpleDownloader(force_chunk_size=20,)]


### PR DESCRIPTION
Issue reported in https://github.com/Backblaze/B2_Command_Line_Tool/pull/565 with a patch provided by @oligriffiths, I just added tests and migrated the patch to the correct repository.