### PR TITLE
Add timeout to python requests, handling backblaze API hangs

### DIFF
--- a/b2sdk/b2http.py
+++ b/b2sdk/b2http.py
@@ -28,9 +28,6 @@ from six.moves import range
 
 logger = logging.getLogger(__name__)
 
-# the timeout used for requests
-TIMEOUT = 10
-
 def _print_exception(e, indent=''):
     """
     Used for debugging to print out nested exception structures.
@@ -238,6 +235,10 @@ class B2Http(object):
 
     """
 
+
+    # timeout for HTTP GET/POST requests
+    TIMEOUT = 120
+
     def __init__(self, requests_module=None, install_clock_skew_hook=True):
         """
         Initialize with a reference to the requests module, which makes
@@ -289,7 +290,7 @@ class B2Http(object):
         def do_post():
             data.seek(0)
             self._run_pre_request_hooks('POST', url, headers)
-            response = self.session.post(url, headers=headers, data=data, timeout=TIMEOUT)
+            response = self.session.post(url, headers=headers, data=data, timeout=self.TIMEOUT)
             self._run_post_request_hooks('POST', url, headers, response)
             return response
 
@@ -357,7 +358,7 @@ class B2Http(object):
         # Do the HTTP GET.
         def do_get():
             self._run_pre_request_hooks('GET', url, headers)
-            response = self.session.get(url, headers=headers, stream=True, timeout=TIMEOUT)
+            response = self.session.get(url, headers=headers, stream=True, timeout=self.TIMEOUT)
             self._run_post_request_hooks('GET', url, headers, response)
             return response
 

--- a/b2sdk/b2http.py
+++ b/b2sdk/b2http.py
@@ -28,6 +28,8 @@ from six.moves import range
 
 logger = logging.getLogger(__name__)
 
+# the timeout used for requests
+TIMEOUT = 10
 
 def _print_exception(e, indent=''):
     """
@@ -287,7 +289,7 @@ class B2Http(object):
         def do_post():
             data.seek(0)
             self._run_pre_request_hooks('POST', url, headers)
-            response = self.session.post(url, headers=headers, data=data)
+            response = self.session.post(url, headers=headers, data=data, timeout=TIMEOUT)
             self._run_post_request_hooks('POST', url, headers, response)
             return response
 
@@ -355,7 +357,7 @@ class B2Http(object):
         # Do the HTTP GET.
         def do_get():
             self._run_pre_request_hooks('GET', url, headers)
-            response = self.session.get(url, headers=headers, stream=True)
+            response = self.session.get(url, headers=headers, stream=True, timeout=TIMEOUT)
             self._run_post_request_hooks('GET', url, headers, response)
             return response
 

--- a/b2sdk/b2http.py
+++ b/b2sdk/b2http.py
@@ -237,7 +237,7 @@ class B2Http(object):
     """
 
     # timeout for HTTP GET/POST requests
-    TIMEOUT = 120
+    TIMEOUT = 130
 
     def __init__(self, requests_module=None, install_clock_skew_hook=True):
         """

--- a/b2sdk/b2http.py
+++ b/b2sdk/b2http.py
@@ -28,6 +28,7 @@ from six.moves import range
 
 logger = logging.getLogger(__name__)
 
+
 def _print_exception(e, indent=''):
     """
     Used for debugging to print out nested exception structures.
@@ -234,7 +235,6 @@ class B2Http(object):
            ...
 
     """
-
 
     # timeout for HTTP GET/POST requests
     TIMEOUT = 120

--- a/test/test_b2http.py
+++ b/test/test_b2http.py
@@ -187,7 +187,9 @@ class TestB2Http(TestBase):
         self.response.status_code = 200
         with self.b2_http.get_content(self.URL, self.HEADERS) as r:
             self.assertTrue(self.response is r)  # no assertIs until 2.7
-        self.session.get.assert_called_with(self.URL, headers=self.EXPECTED_HEADERS, stream=True, timeout=B2Http.TIMEOUT)
+        self.session.get.assert_called_with(
+            self.URL, headers=self.EXPECTED_HEADERS, stream=True, timeout=B2Http.TIMEOUT
+        )
         self.response.close.assert_called_with()
 
 

--- a/test/test_b2http.py
+++ b/test/test_b2http.py
@@ -187,7 +187,7 @@ class TestB2Http(TestBase):
         self.response.status_code = 200
         with self.b2_http.get_content(self.URL, self.HEADERS) as r:
             self.assertTrue(self.response is r)  # no assertIs until 2.7
-        self.session.get.assert_called_with(self.URL, headers=self.EXPECTED_HEADERS, stream=True)
+        self.session.get.assert_called_with(self.URL, headers=self.EXPECTED_HEADERS, stream=True, timeout=B2Http.TIMEOUT)
         self.response.close.assert_called_with()
 
 


### PR DESCRIPTION
Fixes #31.  Maybe.  I can't reproduce the original errors reliably enough.  