### PR TITLE
Drop Jython build from CI and Jython support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,6 @@ matrix:
         homebrew:
           packages: python3
 
-    # jython
-    # It looks like Jython has a similar TLS problem to the Mac:
-    #   An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform.
-#    - python: 2.7
-#      env: JYTHON=true
-
     # pypy
     - python: pypy
       env: PYPY_VERSION=pypy-4.0.1
@@ -89,10 +83,6 @@ cache:
     - $HOME/.eggs
     # custom pypy versions
     - $HOME/.pyenv
-    # jython
-    - $HOME/.virtualenvs/jython
-    - $HOME/jython
-    - $HOME/jython-pip
     # OS X
     - $HOME/.virtualenvs/osx-python3
     #- /usr/local/Cellar/python3
@@ -112,67 +102,6 @@ before_install:
             source "$HOME/.virtualenvs/osx-$OS_X_PYTHON_VERSION/bin/activate"
         else
             echo skip
-        fi
-  - |
-        # get jython
-        if [ -n "$JYTHON" ]; then
-            # When the system python changes version, the symlink to it inside jython
-            # breaks, and jython stops working.  If that happens, remove the installed
-            # version and start over.
-            if [ -d "$HOME/jython" ]; then
-                if "$HOME/jython/bin/jython" --version; then
-                    echo jython version works
-                else
-                    echo jython is broken.  removing it.
-                    rm -rf "$HOME/jython"
-                fi
-            fi
-
-            # Install jython if it's not there.
-            if [ ! -d "$HOME/jython" ]; then
-                travis_retry wget http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.1b3/jython-installer-2.7.1b3.jar -O jython-installer-2.7.1b3.jar
-                java -jar jython-installer-2.7.1b3.jar --silent --directory "$HOME/jython"
-            else
-                echo skip install jython
-            fi
-
-            # install a custom version of pip, as standard pip doesn't work on jython (https://github.com/jythontools/pip/commits/develop)
-            if [ ! -d "$HOME/jython-pip" ]; then
-                mkdir ~/jython-pip
-            else
-                echo skip mkdir jython-pip
-            fi
-            if [ ! -f ~/jython-pip/pip-7.1.2-py2.py3-none-any.whl ]; then
-                travis_retry wget https://pypi.python.org/packages/py2.py3/p/pip/pip-7.1.2-py2.py3-none-any.whl -O ~/jython-pip/pip-7.1.2-py2.py3-none-any.whl
-            else
-                echo skip download pip
-            fi
-
-            # The virtualenv is another place where the cache can hold broken symlinks.
-            # If the virtualenv doesn't work, remove it.
-            export JAVA_OPTS="-Xms128m -Xmx1024m"
-            if [ -f "$HOME/.virtualenvs/jython/bin/activate" ]; then
-                source "$HOME/.virtualenvs/jython/bin/activate"
-                if python --version; then
-                    echo jython virtualenv works
-                else
-                    echo jython virtualenv broken.  removing it.
-                    rm -rf "$HOME/.virtualenvs/jython"
-                fi
-                deactivate
-            fi
-
-            # create jython virtualenv
-            if [ ! -f "$HOME/.virtualenvs/jython/bin/activate" ]; then
-                virtualenv --system-site-packages --extra-search-dir="$HOME/jython-pip" -p "$HOME/jython/bin/jython" "$HOME/.virtualenvs/jython"
-            else
-                echo skip virtualenv
-            fi
-
-            # Activate the virtualenv
-            source "$HOME/.virtualenvs/jython/bin/activate"
-        else
-            echo skip setting up jython
         fi
   - |
         # upgrade pypy (to a version that works with Cryptography 1.0)
@@ -226,8 +155,6 @@ install:
 
 before_script:
   - pip freeze
-  # Before runing the test case, we need to make jython run some code as in first run it can put something on stdout
-  - if [ -n "$JYTHON" ]; then python -c "print ''"; else echo skip; fi
 
 script:
   - |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We encourage outside contributors to perform changes on our codebase. Many such 
 * provide tool assisted code review (through the Pull Request system)
 * maintain a set of integration tests (run with a production cloud)
 * maintain a set of (well over a hundred) unit tests
-* automatically run unit tests on 14 versions of python (including osx, Jython and pypy)
+* automatically run unit tests on 13 versions of python (including osx and pypy)
 * format the code automatically using [yapf](https://github.com/google/yapf)
 * use static code analysis to find subtle/potential issues with maintainability
 * maintain other Continous Integration tools (coverage tracker)

--- a/b2sdk/account_info/sqlite_account_info.py
+++ b/b2sdk/account_info/sqlite_account_info.py
@@ -11,16 +11,13 @@
 import json
 import logging
 import os
-import platform
 import stat
 import threading
 
 from .exception import (CorruptAccountInfo, MissingAccountData)
 from .upload_url_pool import UrlPoolAccountInfo
 
-if not platform.system().lower().startswith('java'):
-    # in Jython 2.7.1b3 there is no sqlite3
-    import sqlite3
+import sqlite3
 
 logger = logging.getLogger(__name__)
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -10,7 +10,7 @@ We encourage outside contributors to perform changes on our codebase. Many such 
 * provide tool assisted code review (through the Pull Request system)
 * maintain a set of integration tests (run with a production cloud)
 * maintain a set of (well over a hundred) unit tests
-* automatically run unit tests on 14 versions of python (including ``osx``, ``Jython`` and ``pypy``)
+* automatically run unit tests on 13 versions of python (including ``osx`` and ``pypy``)
 * format the code automatically using `yapf <https://github.com/google/yapf>`_
 * use static code analysis to find subtle/potential issues with maintainability
 * maintain other Continous Integration tools (coverage tracker)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
 
-import platform
 import sys
 
 # Always prefer setuptools over distutils
@@ -38,12 +37,6 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 with open('requirements.txt', encoding='utf-8') as f:
     requirements = f.read().splitlines()
-
-# Jython cannot handle extremely large blocks of code.
-# requests 2.12.x that we rely on, relied on idna, which until 2.2.0 contained such block.
-# https://github.com/kennethreitz/requests/issues/3711#issuecomment-268522266
-if platform.system().lower().startswith('java'):
-    requirements.append('idna>=2.2.0')
 
 with open('requirements-test.txt', encoding='utf-8') as f:
     requirements_test = f.read().splitlines()

--- a/test/v1/test_account_info.py
+++ b/test/v1/test_account_info.py
@@ -21,12 +21,8 @@ import six
 
 from .test_base import TestBase
 
-from .deps import AbstractAccountInfo, InMemoryAccountInfo, UploadUrlPool
+from .deps import AbstractAccountInfo, InMemoryAccountInfo, UploadUrlPool, SqliteAccountInfo
 from .deps_exception import CorruptAccountInfo, MissingAccountData
-
-if not platform.system().lower().startswith('java'):
-    # in Jython 2.7.1b3 there is no sqlite3
-    from .deps import SqliteAccountInfo
 
 try:
     import unittest.mock as mock
@@ -216,9 +212,6 @@ class TestSqliteAccountInfo(AccountInfoBase, TestBase):
         ).name
 
     def setUp(self):
-        if platform.system().lower().startswith('java'):
-            # in Jython 2.7.1b3 there is no sqlite3
-            raise SkipTest()
         try:
             os.unlink(self.db_path)
         except OSError:

--- a/test/v1/test_bucket.py
+++ b/test/v1/test_bucket.py
@@ -302,9 +302,7 @@ class TestUpload(TestCaseWithBucket):
             self._check_file_contents('file1', data)
 
     def test_upload_fifo(self):
-        if platform.system().lower().startswith('java'):
-            raise SkipTest('in Jython 2.7.1b3 there is no os.mkfifo()')
-        elif platform.system() == 'Windows':
+        if platform.system() == 'Windows':
             raise SkipTest('no os.mkfifo() on Windows')
         with TempDir() as d:
             path = os.path.join(d, 'file1')


### PR DESCRIPTION
it is broken for years with no hope of repair. I tried to fix it today, but only discovered that in addition to issue which caused our build to fail, travis dropped support for jdk that jython was using (if I understood correctly). There is no python3 support, no releases for years, there are issues with jython documentation being inaccessible due to the server hosting it throwing a 500.

We thank the jython build for discovering a race condition in our threaded code a few years back, but it's time to say goodbye.