### PR TITLE
Fix bad key name in as_list_files_dict

### DIFF
--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -204,7 +204,7 @@ class FileSimulator(object):
         return dict(
             fileId=self.file_id,
             fileName=self.name,
-            size=len(self.data_bytes) if self.data_bytes is not None else 0,
+            contentLength=len(self.data_bytes) if self.data_bytes is not None else 0,
             contentType=self.content_type,
             contentSha1=self.content_sha1,
             fileInfo=self.file_info,


### PR DESCRIPTION
The official docs say the filesize is reported in the "contentLength" property.