### PR TITLE
Refactor upload token logic to B2Session

### DIFF
--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -521,31 +521,22 @@ class Bucket(object):
         self, upload_source, file_name, content_type, file_info, progress_listener
     ):
         content_length = upload_source.get_content_length()
-        upload_url = None
         exception_info_list = []
         progress_listener.set_total_bytes(content_length)
         with progress_listener:
             for _ in six.moves.xrange(self.MAX_UPLOAD_ATTEMPTS):
-                # refresh upload data in every attempt to work around a "busy storage pod"
-                upload_url, upload_auth_token = self._get_upload_data()
-
                 try:
                     with upload_source.open() as file:
                         input_stream = ReadingStreamWithProgress(file, progress_listener)
                         hashing_stream = StreamWithHash(input_stream)
                         length_with_hash = content_length + hashing_stream.hash_size()
-                        response = self.api.raw_api.upload_file(
-                            upload_url, upload_auth_token, file_name, length_with_hash,
-                            content_type, HEX_DIGITS_AT_END, file_info, hashing_stream
+                        response = self.api.session.upload_file(
+                            self.id_, None, file_name, length_with_hash, content_type,
+                            HEX_DIGITS_AT_END, file_info, hashing_stream
                         )
                         assert hashing_stream.hash == response['contentSha1']
-                        self.api.account_info.put_bucket_upload_url(
-                            self.id_, upload_url, upload_auth_token
-                        )
                         return FileVersionInfoFactory.from_api_response(response)
-
                 except B2Error as e:
-                    logger.exception('error when uploading, upload_url was %s', upload_url)
                     if not e.should_retry_upload():
                         raise
                     exception_info_list.append(e)
@@ -664,13 +655,9 @@ class Bucket(object):
         # Set up a progress listener
         part_progress_listener = PartProgressReporter(large_file_upload_state)
 
-        upload_url = None
         # Retry the upload as needed
         exception_list = []
         for _ in six.moves.xrange(self.MAX_UPLOAD_ATTEMPTS):
-            # refresh upload data in every attempt to work around a "busy storage pod"
-            upload_url, upload_auth_token = self._get_upload_part_data(file_id)
-
             # if another part has already had an error there's no point in
             # uploading this part
             if large_file_upload_state.has_error():
@@ -684,51 +671,18 @@ class Bucket(object):
                     input_stream = ReadingStreamWithProgress(range_stream, part_progress_listener)
                     hashing_stream = StreamWithHash(input_stream)
                     length_with_hash = content_length + hashing_stream.hash_size()
-                    response = self.api.raw_api.upload_part(
-                        upload_url, upload_auth_token, part_number, length_with_hash,
-                        HEX_DIGITS_AT_END, hashing_stream
+                    response = self.api.session.upload_part(
+                        self.id_, file_id, part_number, length_with_hash, HEX_DIGITS_AT_END,
+                        hashing_stream
                     )
                     assert hashing_stream.hash == response['contentSha1']
-                    self.api.account_info.put_large_file_upload_url(
-                        file_id, upload_url, upload_auth_token
-                    )
                     return response
-
             except B2Error as e:
-                logger.exception('error when uploading, upload_url was %s', upload_url)
-                if not e.should_retry_upload():
-                    raise
                 exception_list.append(e)
                 self.api.account_info.clear_bucket_upload_data(self.id_)
 
         large_file_upload_state.set_error(str(exception_list[-1]))
         raise MaxRetriesExceeded(self.MAX_UPLOAD_ATTEMPTS, exception_list)
-
-    def _get_upload_data(self):
-        """
-        Take ownership of an upload URL / auth token for the bucket and
-        return it.
-        """
-        account_info = self.api.account_info
-        upload_url, upload_auth_token = account_info.take_bucket_upload_url(self.id_)
-        if None not in (upload_url, upload_auth_token):
-            return upload_url, upload_auth_token
-
-        response = self.api.session.get_upload_url(self.id_)
-        return response['uploadUrl'], response['authorizationToken']
-
-    def _get_upload_part_data(self, file_id):
-        """
-        Make sure that we have an upload URL and auth token for the given bucket and
-        return it.
-        """
-        account_info = self.api.account_info
-        upload_url, upload_auth_token = account_info.take_large_file_upload_url(file_id)
-        if None not in (upload_url, upload_auth_token):
-            return upload_url, upload_auth_token
-
-        response = self.api.session.get_upload_part_url(file_id)
-        return (response['uploadUrl'], response['authorizationToken'])
 
     def get_download_url(self, filename):
         """

--- a/b2sdk/raw_api.py
+++ b/b2sdk/raw_api.py
@@ -60,8 +60,8 @@ class TokenType(Enum):
 
 def set_token_type(token_type):
     """
-    This is a decorator to identify the type of token to be used in session.
-    When the raw_api is used through B2Session, it will be used to identify the type of url and token to be used.
+    This is a decorator to identify the type of token that must be passed into a function.
+    When the raw_api is used through B2Session, it will be used to identify the type of url and token to be passed.
 
     :param token_type: TokenType enum
     :return:
@@ -72,6 +72,17 @@ def set_token_type(token_type):
         return func
 
     return inner
+
+
+def get_token_type(func):
+    """
+    This will return the token type that must be passed into the input raw_api function.
+    The default value is TokenType.API.
+
+    :param func: raw_api function to be called
+    :return: token type
+    """
+    return getattr(func, 'token_type', TokenType.API)
 
 
 @unique

--- a/b2sdk/raw_api.py
+++ b/b2sdk/raw_api.py
@@ -52,6 +52,29 @@ API_VERSION = 'v2'
 
 
 @unique
+class TokenType(Enum):
+    API = 'api'
+    UPLOAD_PART = 'upload_part'
+    UPLOAD_SMALL = 'upload_small'
+
+
+def set_token_type(token_type):
+    """
+    This is a decorator to identify the type of token to be used in session.
+    When the raw_api is used through B2Session, it will be used to identify the type of url and token to be used.
+
+    :param token_type: TokenType enum
+    :return:
+    """
+
+    def inner(func, *args, **kwargs):
+        func.token_type = token_type
+        return func
+
+    return inner
+
+
+@unique
 class MetadataDirectiveMode(Enum):
     COPY = 401
     REPLACE = 402
@@ -502,6 +525,7 @@ class B2RawApi(AbstractRawApi):
         if long_segment > 250:
             raise UnusableFileName("Filename segment too long (maximum 250 bytes in utf-8).")
 
+    @set_token_type(TokenType.UPLOAD_SMALL)
     def upload_file(
         self, upload_url, upload_auth_token, file_name, content_length, content_type, content_sha1,
         file_infos, data_stream
@@ -533,6 +557,7 @@ class B2RawApi(AbstractRawApi):
 
         return self.b2_http.post_content_return_json(upload_url, headers, data_stream)
 
+    @set_token_type(TokenType.UPLOAD_PART)
     def upload_part(
         self, upload_url, upload_auth_token, part_number, content_length, content_sha1, data_stream
     ):

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -30,7 +30,7 @@ from .exception import (
     Unauthorized,
     UnsatisfiableRange,
 )
-from .raw_api import AbstractRawApi, HEX_DIGITS_AT_END, MetadataDirectiveMode
+from .raw_api import AbstractRawApi, HEX_DIGITS_AT_END, MetadataDirectiveMode, set_token_type, TokenType
 from .utils import b2_url_decode, b2_url_encode
 
 ALL_CAPABILITES = [
@@ -1065,6 +1065,7 @@ class RawSimulator(AbstractRawApi):
             if_revision_is=if_revision_is
         )
 
+    @set_token_type(TokenType.UPLOAD_SMALL)
     def upload_file(
         self, upload_url, upload_auth_token, file_name, content_length, content_type, content_sha1,
         file_infos, data_stream
@@ -1085,6 +1086,7 @@ class RawSimulator(AbstractRawApi):
         self.file_id_to_bucket_id[file_id] = bucket_id
         return response
 
+    @set_token_type(TokenType.UPLOAD_PART)
     def upload_part(
         self, upload_url, upload_auth_token, part_number, content_length, sha1_sum, input_stream
     ):

--- a/b2sdk/session.py
+++ b/b2sdk/session.py
@@ -11,7 +11,7 @@
 import functools
 
 from b2sdk.exception import (InvalidAuthToken, Unauthorized)
-from b2sdk.raw_api import ALL_CAPABILITIES, TokenType
+from b2sdk.raw_api import ALL_CAPABILITIES, get_token_type, TokenType
 
 
 class B2Session(object):
@@ -31,7 +31,7 @@ class B2Session(object):
         def wrapper(*args, **kwargs):
             auth_failure_encountered = False
             # A *magic* that will identify and generate the correct type of Url and token based on the decorator on the B2RawApi method.
-            token_type = getattr(f, 'token_type', TokenType.API)
+            token_type = get_token_type(f)
             # download_by_name uses different URLs
             url_factory = kwargs.pop('url_factory', self._api.account_info.get_api_url)
             while 1:

--- a/b2sdk/v1/__init__.py
+++ b/b2sdk/v1/__init__.py
@@ -68,6 +68,7 @@ from b2sdk.raw_simulator import RawSimulator
 from b2sdk.raw_api import AbstractRawApi
 from b2sdk.raw_api import B2RawApi
 from b2sdk.raw_api import MetadataDirectiveMode
+from b2sdk.raw_api import TokenType
 
 # progress
 

--- a/test/v0/test_session.py
+++ b/test/v0/test_session.py
@@ -13,6 +13,7 @@ from .test_base import TestBase
 from .deps_exception import InvalidAuthToken, Unauthorized
 from .deps import ALL_CAPABILITIES
 from .deps import B2Session
+from .deps import TokenType
 
 try:
     import unittest.mock as mock
@@ -30,6 +31,7 @@ class TestB2Session(TestBase):
 
         self.raw_api = mock.MagicMock()
         self.raw_api.do_it.__name__ = 'do_it'
+        self.raw_api.do_it.token_type = TokenType.API
         self.raw_api.do_it.side_effect = ['ok']
 
         self.session = B2Session(self.api, self.raw_api)

--- a/test/v1/test_session.py
+++ b/test/v1/test_session.py
@@ -13,6 +13,7 @@ from .test_base import TestBase
 from .deps_exception import InvalidAuthToken, Unauthorized
 from .deps import ALL_CAPABILITIES
 from .deps import B2Session
+from .deps import TokenType
 
 try:
     import unittest.mock as mock
@@ -30,6 +31,7 @@ class TestB2Session(TestBase):
 
         self.raw_api = mock.MagicMock()
         self.raw_api.do_it.__name__ = 'do_it'
+        self.raw_api.do_it.token_type = TokenType.API
         self.raw_api.do_it.side_effect = ['ok']
 
         self.session = B2Session(self.api, self.raw_api)


### PR DESCRIPTION
As part of #77 we are moving upload url and token logic to B2Session where it actually belongs.