### PR TITLE
B2session refactor

### DIFF
--- a/b2sdk/api.py
+++ b/b2sdk/api.py
@@ -109,6 +109,11 @@ class B2Api(object):
 
     @property
     def raw_api(self):
+        """
+        .. warning::
+            :class:`~b2sdk.raw_api.B2RawApi` attribute is deprecated.
+            :class:`~b2sdk.session.B2Session` expose all :class:`~b2sdk.raw_api.B2RawApi` methods now."""
+        # TODO: add deprecation warning
         return self.session.raw_api
 
     def set_thread_pool_size(self, max_workers):

--- a/b2sdk/api.py
+++ b/b2sdk/api.py
@@ -113,7 +113,6 @@ class B2Api(object):
         .. warning::
             :class:`~b2sdk.raw_api.B2RawApi` attribute is deprecated.
             :class:`~b2sdk.session.B2Session` expose all :class:`~b2sdk.raw_api.B2RawApi` methods now."""
-        # TODO: add deprecation warning
         return self.session.raw_api
 
     def set_thread_pool_size(self, max_workers):

--- a/b2sdk/api.py
+++ b/b2sdk/api.py
@@ -94,19 +94,22 @@ class B2Api(object):
 
         :param int max_upload_workers: a number of upload threads, default is 10
         """
-        self.raw_api = raw_api or B2RawApi(B2Http())
-        if account_info is None:
-            account_info = SqliteAccountInfo()
-            if cache is None:
-                cache = AuthInfoCache(account_info)
-        self.session = B2Session(self, self.raw_api)
+        self.session = B2Session(account_info=account_info, cache=cache, raw_api=raw_api)
         self.transferer = Transferer(self.session, account_info)
-        self.account_info = account_info
-        if cache is None:
-            cache = DummyCache()
-        self.cache = cache
         self.upload_executor = None
         self.max_workers = max_upload_workers
+
+    @property
+    def account_info(self):
+        return self.session.account_info
+
+    @property
+    def cache(self):
+        return self.session.cache
+
+    @property
+    def raw_api(self):
+        return self.session.raw_api
 
     def set_thread_pool_size(self, max_workers):
         """
@@ -137,15 +140,7 @@ class B2Api(object):
         Perform automatic account authorization, retrieving all account data
         from account info object passed during initialization.
         """
-        try:
-            self.authorize_account(
-                self.account_info.get_realm(),
-                self.account_info.get_application_key_id(),
-                self.account_info.get_application_key(),
-            )
-        except MissingAccountData:
-            return False
-        return True
+        return self.session.authorize_automatically()
 
     @limit_trace_arguments(only=('self', 'realm'))
     def authorize_account(self, realm, application_key_id, application_key):
@@ -156,32 +151,7 @@ class B2Api(object):
         :param str application_key_id: :term:`application key ID`
         :param str application_key: user's :term:`application key`
         """
-        # Clean up any previous account info if it was for a different account.
-        try:
-            old_account_id = self.account_info.get_account_id()
-            old_realm = self.account_info.get_realm()
-            if application_key_id != old_account_id or realm != old_realm:
-                self.cache.clear()
-        except MissingAccountData:
-            self.cache.clear()
-
-        # Authorize
-        realm_url = self.account_info.REALM_URLS[realm]
-        response = self.raw_api.authorize_account(realm_url, application_key_id, application_key)
-        allowed = response['allowed']
-
-        # Store the auth data
-        self.account_info.set_auth_data(
-            response['accountId'],
-            response['authorizationToken'],
-            response['apiUrl'],
-            response['downloadUrl'],
-            response['recommendedPartSize'],
-            application_key,
-            realm,
-            allowed,
-            application_key_id,
-        )
+        self.session.authorize_account(realm, application_key_id, application_key)
 
     def get_account_id(self):
         """
@@ -245,10 +215,7 @@ class B2Api(object):
         position, and the second one is the end position in the file
         :return: context manager that returns an object that supports iter_content()
         """
-        url = self.session.get_download_url_by_id(
-            file_id,
-            url_factory=self.account_info.get_download_url,
-        )
+        url = self.session.get_download_url_by_id(file_id)
         return self.transferer.download_file_from_url(url, download_dest, progress_listener, range_)
 
     def get_bucket_by_id(self, bucket_id):

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -253,11 +253,7 @@ class Bucket(object):
         :param b2sdk.v1.AbstractProgressListener, None progress_listener: a progress listener object to use, or ``None`` to not track progress
         :param tuple[int, int] range_: two integer values, start and end offsets
         """
-        url = self.api.session.get_download_url_by_name(
-            self.name,
-            file_name,
-            url_factory=self.api.account_info.get_download_url,
-        )
+        url = self.api.session.get_download_url_by_name(self.name, file_name)
         return self.api.transferer.download_file_from_url(
             url, download_dest, progress_listener, range_
         )
@@ -535,8 +531,8 @@ class Bucket(object):
                         hashing_stream = StreamWithHash(input_stream)
                         length_with_hash = content_length + hashing_stream.hash_size()
                         response = self.api.session.upload_file(
-                            self.id_, None, file_name, length_with_hash, content_type,
-                            HEX_DIGITS_AT_END, file_info, hashing_stream
+                            self.id_, file_name, length_with_hash, content_type, HEX_DIGITS_AT_END,
+                            file_info, hashing_stream
                         )
                         assert hashing_stream.hash == response['contentSha1']
                         return FileVersionInfoFactory.from_api_response(response)
@@ -676,8 +672,7 @@ class Bucket(object):
                     hashing_stream = StreamWithHash(input_stream)
                     length_with_hash = content_length + hashing_stream.hash_size()
                     response = self.api.session.upload_part(
-                        self.id_, file_id, part_number, length_with_hash, HEX_DIGITS_AT_END,
-                        hashing_stream
+                        file_id, part_number, length_with_hash, HEX_DIGITS_AT_END, hashing_stream
                     )
                     assert hashing_stream.hash == response['contentSha1']
                     return response

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -30,7 +30,7 @@ from .exception import (
     Unauthorized,
     UnsatisfiableRange,
 )
-from .raw_api import AbstractRawApi, HEX_DIGITS_AT_END, MetadataDirectiveMode, set_token_type, TokenType
+from .raw_api import AbstractRawApi, HEX_DIGITS_AT_END, MetadataDirectiveMode
 from .utils import b2_url_decode, b2_url_encode
 
 ALL_CAPABILITES = [
@@ -825,7 +825,7 @@ class RawSimulator(AbstractRawApi):
         del self.bucket_id_to_bucket[bucket_id]
         return bucket.bucket_dict()
 
-    def download_file_from_url(self, _, account_auth_token_or_none, url, range_=None):
+    def download_file_from_url(self, account_auth_token_or_none, url, range_=None):
         # TODO: check auth token if bucket is not public
         matcher = self.DOWNLOAD_URL_MATCHER.match(url)
         assert matcher is not None, url
@@ -1077,7 +1077,6 @@ class RawSimulator(AbstractRawApi):
             if_revision_is=if_revision_is
         )
 
-    @set_token_type(TokenType.UPLOAD_SMALL)
     def upload_file(
         self, upload_url, upload_auth_token, file_name, content_length, content_type, content_sha1,
         file_infos, data_stream
@@ -1098,7 +1097,6 @@ class RawSimulator(AbstractRawApi):
         self.file_id_to_bucket_id[file_id] = bucket_id
         return response
 
-    @set_token_type(TokenType.UPLOAD_PART)
     def upload_part(
         self, upload_url, upload_auth_token, part_number, content_length, sha1_sum, input_stream
     ):

--- a/b2sdk/session.py
+++ b/b2sdk/session.py
@@ -179,7 +179,8 @@ class B2Session(object):
 
     def get_download_authorization(self, bucket_id, file_name_prefix, valid_duration_in_seconds):
         return self._wrap_default_token(
-            self.raw_api.get_download_authorization, bucket_id, file_name_prefix, valid_duration_in_seconds
+            self.raw_api.get_download_authorization, bucket_id, file_name_prefix,
+            valid_duration_in_seconds
         )
 
     def get_file_info(self, file_id):
@@ -243,7 +244,9 @@ class B2Session(object):
         )
 
     def list_parts(self, file_id, start_part_number, max_part_count):
-        return self._wrap_default_token(self.raw_api.list_parts, file_id, start_part_number, max_part_count)
+        return self._wrap_default_token(
+            self.raw_api.list_parts, file_id, start_part_number, max_part_count
+        )
 
     def list_unfinished_large_files(
         self,

--- a/b2sdk/transferer/transferer.py
+++ b/b2sdk/transferer/transferer.py
@@ -74,11 +74,7 @@ class Transferer(object):
         """
         progress_listener = progress_listener or DoNothingProgressListener()
         download_dest = DownloadDestProgressWrapper(download_dest, progress_listener)
-        with self.session.download_file_from_url(
-            url,
-            url_factory=self.account_info.get_download_url,
-            range_=range_,
-        ) as response:
+        with self.session.download_file_from_url(url, range_=range_) as response:
             metadata = FileMetadata.from_response(response)
             if range_ is not None:
                 if 'Content-Range' not in response.headers:

--- a/b2sdk/v1/__init__.py
+++ b/b2sdk/v1/__init__.py
@@ -81,7 +81,6 @@ from b2sdk.raw_simulator import RawSimulator
 from b2sdk.raw_api import AbstractRawApi
 from b2sdk.raw_api import B2RawApi
 from b2sdk.raw_api import MetadataDirectiveMode
-from b2sdk.raw_api import TokenType
 
 # progress
 

--- a/test/v0/test_session.py
+++ b/test/v0/test_session.py
@@ -13,7 +13,6 @@ from .test_base import TestBase
 from .deps_exception import InvalidAuthToken, Unauthorized
 from .deps import ALL_CAPABILITIES
 from .deps import B2Session
-from .deps import TokenType
 
 try:
     import unittest.mock as mock
@@ -30,29 +29,28 @@ class TestB2Session(TestBase):
         self.api.account_info = self.account_info
 
         self.raw_api = mock.MagicMock()
-        self.raw_api.do_it.__name__ = 'do_it'
-        self.raw_api.do_it.token_type = TokenType.API
-        self.raw_api.do_it.side_effect = ['ok']
+        self.raw_api.get_file_info.__name__ = 'get_file_info'
+        self.raw_api.get_file_info.side_effect = ['ok']
 
-        self.session = B2Session(self.api, self.raw_api)
+        self.session = B2Session(self.account_info, raw_api=self.raw_api)
 
     def test_works_first_time(self):
-        self.assertEqual('ok', self.session.do_it())
+        self.assertEqual('ok', self.session.get_file_info(None))
 
     def test_works_second_time(self):
-        self.raw_api.do_it.side_effect = [
+        self.raw_api.get_file_info.side_effect = [
             InvalidAuthToken('message', 'code'),
             'ok',
         ]
-        self.assertEqual('ok', self.session.do_it())
+        self.assertEqual('ok', self.session.get_file_info(None))
 
     def test_fails_second_time(self):
-        self.raw_api.do_it.side_effect = [
+        self.raw_api.get_file_info.side_effect = [
             InvalidAuthToken('message', 'code'),
             InvalidAuthToken('message', 'code'),
         ]
         with self.assertRaises(InvalidAuthToken):
-            self.session.do_it()
+            self.session.get_file_info(None)
 
     def test_app_key_info_no_info(self):
         self.account_info.get_allowed.return_value = dict(
@@ -61,11 +59,11 @@ class TestB2Session(TestBase):
             capabilities=ALL_CAPABILITIES,
             namePrefix=None,
         )
-        self.raw_api.do_it.side_effect = Unauthorized('no_go', 'code')
+        self.raw_api.get_file_info.side_effect = Unauthorized('no_go', 'code')
         with self.assertRaisesRegexp(
             Unauthorized, r'no_go for application key with no restrictions \(code\)'
         ):
-            self.session.do_it()
+            self.session.get_file_info(None)
 
     def test_app_key_info_no_info_no_message(self):
         self.account_info.get_allowed.return_value = dict(
@@ -74,11 +72,11 @@ class TestB2Session(TestBase):
             capabilities=ALL_CAPABILITIES,
             namePrefix=None,
         )
-        self.raw_api.do_it.side_effect = Unauthorized('', 'code')
+        self.raw_api.get_file_info.side_effect = Unauthorized('', 'code')
         with self.assertRaisesRegexp(
             Unauthorized, r'unauthorized for application key with no restrictions \(code\)'
         ):
-            self.session.do_it()
+            self.session.get_file_info(None)
 
     def test_app_key_info_all_info(self):
         self.account_info.get_allowed.return_value = dict(
@@ -87,9 +85,9 @@ class TestB2Session(TestBase):
             capabilities=['readFiles'],
             namePrefix='prefix/',
         )
-        self.raw_api.do_it.side_effect = Unauthorized('no_go', 'code')
+        self.raw_api.get_file_info.side_effect = Unauthorized('no_go', 'code')
         with self.assertRaisesRegexp(
             Unauthorized,
             r"no_go for application key with capabilities 'readFiles', restricted to bucket 'my-bucket', restricted to files that start with 'prefix/' \(code\)"
         ):
-            self.session.do_it()
+            self.session.get_file_info(None)

--- a/test/v1/test_session.py
+++ b/test/v1/test_session.py
@@ -13,7 +13,6 @@ from .test_base import TestBase
 from .deps_exception import InvalidAuthToken, Unauthorized
 from .deps import ALL_CAPABILITIES
 from .deps import B2Session
-from .deps import TokenType
 
 try:
     import unittest.mock as mock
@@ -30,29 +29,28 @@ class TestB2Session(TestBase):
         self.api.account_info = self.account_info
 
         self.raw_api = mock.MagicMock()
-        self.raw_api.do_it.__name__ = 'do_it'
-        self.raw_api.do_it.token_type = TokenType.API
-        self.raw_api.do_it.side_effect = ['ok']
+        self.raw_api.get_file_info.__name__ = 'get_file_info'
+        self.raw_api.get_file_info.side_effect = ['ok']
 
-        self.session = B2Session(self.api, self.raw_api)
+        self.session = B2Session(self.account_info, raw_api=self.raw_api)
 
     def test_works_first_time(self):
-        self.assertEqual('ok', self.session.do_it())
+        self.assertEqual('ok', self.session.get_file_info(None))
 
     def test_works_second_time(self):
-        self.raw_api.do_it.side_effect = [
+        self.raw_api.get_file_info.side_effect = [
             InvalidAuthToken('message', 'code'),
             'ok',
         ]
-        self.assertEqual('ok', self.session.do_it())
+        self.assertEqual('ok', self.session.get_file_info(None))
 
     def test_fails_second_time(self):
-        self.raw_api.do_it.side_effect = [
+        self.raw_api.get_file_info.side_effect = [
             InvalidAuthToken('message', 'code'),
             InvalidAuthToken('message', 'code'),
         ]
         with self.assertRaises(InvalidAuthToken):
-            self.session.do_it()
+            self.session.get_file_info(None)
 
     def test_app_key_info_no_info(self):
         self.account_info.get_allowed.return_value = dict(
@@ -61,11 +59,11 @@ class TestB2Session(TestBase):
             capabilities=ALL_CAPABILITIES,
             namePrefix=None,
         )
-        self.raw_api.do_it.side_effect = Unauthorized('no_go', 'code')
+        self.raw_api.get_file_info.side_effect = Unauthorized('no_go', 'code')
         with self.assertRaisesRegexp(
             Unauthorized, r'no_go for application key with no restrictions \(code\)'
         ):
-            self.session.do_it()
+            self.session.get_file_info(None)
 
     def test_app_key_info_no_info_no_message(self):
         self.account_info.get_allowed.return_value = dict(
@@ -74,11 +72,11 @@ class TestB2Session(TestBase):
             capabilities=ALL_CAPABILITIES,
             namePrefix=None,
         )
-        self.raw_api.do_it.side_effect = Unauthorized('', 'code')
+        self.raw_api.get_file_info.side_effect = Unauthorized('', 'code')
         with self.assertRaisesRegexp(
             Unauthorized, r'unauthorized for application key with no restrictions \(code\)'
         ):
-            self.session.do_it()
+            self.session.get_file_info(None)
 
     def test_app_key_info_all_info(self):
         self.account_info.get_allowed.return_value = dict(
@@ -87,9 +85,9 @@ class TestB2Session(TestBase):
             capabilities=['readFiles'],
             namePrefix='prefix/',
         )
-        self.raw_api.do_it.side_effect = Unauthorized('no_go', 'code')
+        self.raw_api.get_file_info.side_effect = Unauthorized('no_go', 'code')
         with self.assertRaisesRegexp(
             Unauthorized,
             r"no_go for application key with capabilities 'readFiles', restricted to bucket 'my-bucket', restricted to files that start with 'prefix/' \(code\)"
         ):
-            self.session.do_it()
+            self.session.get_file_info(None)


### PR DESCRIPTION
Make the B2Session code clearer and be explicit about each call rather than relying on magic (and even more magic after recent changes - this was not an ideal direction). Now the constructor of B2Session has defaults, which is also nice.

Furthermore, RawApi interface was repaired.

The use of magic in B2Session has been frowned upon for a very long time now and the review of recent changes (that made it even more magic) made us realize that it is time to restructure it properly.