### PR TITLE
Treat hidden file as deleted in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ b2sdk>=0.0.0,<1.0.0
 
 ## 1.0.4 (not release yet)
 
-* ???
+* Make sync treat hidden files as deleted
 
 ## 1.0.2 (2019-10-15)
 

--- a/b2sdk/sync/policy.py
+++ b/b2sdk/sync/policy.py
@@ -85,7 +85,7 @@ class AbstractFileSyncPolicy(object):
         """
         Decide whether to transfer the file from the source to the destination.
         """
-        if self._source_file is None:
+        if self._source_file is None or self._source_file.latest_version().action == 'hide':
             # No source file.  Nothing to transfer.
             return False
         elif self._dest_file is None:
@@ -292,7 +292,9 @@ class DownAndDeletePolicy(DownPolicy):
     def _get_hide_delete_actions(self):
         for action in super(DownAndDeletePolicy, self)._get_hide_delete_actions():
             yield action
-        if self._dest_file is not None and self._source_file is None:
+        if self._dest_file is not None and (
+            self._source_file is None or self._source_file.latest_version().action == 'hide'
+        ):
             # Local files have either 0 or 1 versions.  If the file is there,
             # it must have exactly 1 version.
             yield LocalDeleteAction(self._dest_file.name, self._dest_file.versions[0].id_)

--- a/b2sdk/v0/sync.py
+++ b/b2sdk/v0/sync.py
@@ -48,7 +48,7 @@ class Synchronizer(SynchronizerV1):
         except InvalidArgument as e:
             raise CommandError('--%s %s' % (e.parameter_name, e.message))
         except IncompleteSync as e:
-            raise CommandError(e.message)
+            raise CommandError(str(e))
 
 
 def get_synchronizer_from_args(


### PR DESCRIPTION
This is to fix Backblaze/B2_Command_Line_Tool#605

There are no unit tests for this area of the code in b2sdk, so a test case is added here: reef-technologies/B2_Command_Line_Tool#23 in the existing test infrastructure