### PR TITLE
Fix constructing Range from HTTP request Range header

### DIFF
--- a/b2sdk/transferer/range.py
+++ b/b2sdk/transferer/range.py
@@ -24,9 +24,9 @@ class Range(object):
         """
         Factory method which returns an object constructed from Range http header.
 
-        raw_range_header example: 'bytes 0-11'
+        raw_range_header example: 'bytes=0-11'
         """
-        offsets = tuple(int(i) for i in raw_range_header.replace('bytes ', '').split('-'))
+        offsets = tuple(int(i) for i in raw_range_header.replace('bytes=', '').split('-'))
         return cls(*offsets)
 
     def size(self):


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
```
GET /z4d4kWk.jpg HTTP/1.1
Host: i.imgur.com
Range: bytes=0-1023
```
```
HTTP/1.1 206 Partial Content
Content-Range: bytes 0-1023/146515
Content-Length: 1024
...
(binary content)
```