### PR TITLE
Prevent directory traversal attack in sync functionality

### DIFF
--- a/b2sdk/sync/exception.py
+++ b/b2sdk/sync/exception.py
@@ -56,3 +56,21 @@ class InvalidArgument(B2Error):
 
 class IncompleteSync(B2SimpleError):
     pass
+
+
+class UnSyncableFilename(B2Error):
+    """
+    Raised when a filename is not supported by the sync operation
+    """
+
+    def __init__(self, message, filename):
+        """
+        :param message: brief explanation of why the filename was not supported
+        :param filename: name of the file which is not supported
+        """
+        super(UnSyncableFilename, self).__init__()
+        self.filename = filename
+        self.message = message
+
+    def __str__(self):
+        return "%s: %s" % (self.message, self.filename)

--- a/b2sdk/sync/folder.py
+++ b/b2sdk/sync/folder.py
@@ -23,7 +23,7 @@ from .scan_policies import DEFAULT_SCAN_MANAGER
 from ..raw_api import SRC_LAST_MODIFIED_MILLIS
 from ..utils import fix_windows_path_limit, is_file_readable
 
-DRIVE_MATCHER = re.compile(r"^([A-Za-z]):([\\/])")
+DRIVE_MATCHER = re.compile(r"^([A-Za-z]):([\\])")
 ABSOLUTE_PATH_MATCHER = re.compile(r"^(/)|^(\\)")
 RELATIVE_PATH_MATCHER = re.compile(
     r"^(\.\.[/\\])|^(\.[/\\])|([/\\]\.\.[/\\])|([/\\]\.[/\\])|([/\\]\.\.)$|([/\\]\.)$|^(\.\.)$|" +
@@ -334,8 +334,8 @@ class B2Folder(AbstractFolder):
                 raise UnSyncableFilename(
                     "sync does not support file names with absolute paths", file_name
                 )
-            # Do not allow Windows drive letters in file names
-            if DRIVE_MATCHER.search(file_name):
+            # On Windows, do not allow drive letters in file names
+            if platform.system() == "Windows" and DRIVE_MATCHER.search(file_name):
                 raise UnSyncableFilename(
                     "sync does not support file names with drive letters", file_name
                 )

--- a/b2sdk/sync/folder.py
+++ b/b2sdk/sync/folder.py
@@ -23,7 +23,7 @@ from .scan_policies import DEFAULT_SCAN_MANAGER
 from ..raw_api import SRC_LAST_MODIFIED_MILLIS
 from ..utils import fix_windows_path_limit, is_file_readable
 
-DRIVE_MATCHER = re.compile(r"^([A-Za-z]):([\\])")
+DRIVE_MATCHER = re.compile(r"^([A-Za-z]):([/\\])")
 ABSOLUTE_PATH_MATCHER = re.compile(r"^(/)|^(\\)")
 RELATIVE_PATH_MATCHER = re.compile(
     r"^(\.\.[/\\])|^(\.[/\\])|([/\\]\.\.[/\\])|([/\\]\.[/\\])|([/\\]\.\.)$|([/\\]\.)$|^(\.\.)$|" +

--- a/b2sdk/sync/folder.py
+++ b/b2sdk/sync/folder.py
@@ -10,6 +10,7 @@
 
 import logging
 import os
+import platform
 import re
 import six
 import sys
@@ -305,6 +306,7 @@ class B2Folder(AbstractFolder):
         """
         current_name = None
         current_versions = []
+        sep = '/' if platform.system() != 'Windows' else '\\\\'
         for (file_version_info, folder_name) in self.bucket.ls(
             self.folder_name, show_versions=True, recursive=True, fetch_count=1000
         ):
@@ -317,15 +319,16 @@ class B2Folder(AbstractFolder):
                 continue
 
             # Do not allow relative paths in file names
-            if (file_name.startswith('..' + os.path.sep) or
-                os.path.sep + '..' + os.path.sep in file_name or
-                file_name.endswith(os.path.sep + '..') or file_name == '..'
+            if (file_name.startswith('../') or
+                '/../' in file_name or
+                file_name.endswith('/..') or
+                file_name == '..'
             ):
                 raise Exception(
                     "sync does not support file names that include relative paths: %s" % file_name
                 )
             # Do not allow absolute paths in file names
-            if file_name.startswith(os.path.sep) or re.match("[A-Za-z]:" + os.path.sep, file_name):
+            if file_name.startswith(sep) or re.match("[A-Za-z]:" + sep, file_name):
                 raise Exception(
                     "sync does not support file names with absolute paths: %s" % file_name
                 )

--- a/b2sdk/sync/folder.py
+++ b/b2sdk/sync/folder.py
@@ -26,9 +26,17 @@ from ..utils import fix_windows_path_limit, is_file_readable
 DRIVE_MATCHER = re.compile(r"^([A-Za-z]):([/\\])")
 ABSOLUTE_PATH_MATCHER = re.compile(r"^(/)|^(\\)")
 RELATIVE_PATH_MATCHER = re.compile(
-    r"^(\.\.[/\\])|^(\.[/\\])|([/\\]\.\.[/\\])|([/\\]\.[/\\])|([/\\]\.\.)$|([/\\]\.)$|^(\.\.)$|" +
-    r"([/\\][/\\])|^(\.)$"
-)
+                           # "abc" and "xyz" represent anything, including "nothing"
+    r"^(\.\.[/\\])|" +     # ../abc or ..\abc
+    r"^(\.[/\\])|" +       # ./abc or .\abc
+    r"([/\\]\.\.[/\\])|" + # abc/../xyz or abc\..\xyz or abc\../xyz or abc/..\xyz
+    r"([/\\]\.[/\\])|" +   # abc/./xyz or abc\.\xyz or abc\./xyz or abc/.\xyz
+    r"([/\\]\.\.)$|" +     # abc/.. or abc\..
+    r"([/\\]\.)$|" +       # abc/. or abc\. 
+    r"^(\.\.)$|" +         # just ".."
+    r"([/\\][/\\])|" +     # abc\/xyz or abc/\xyz or abc//xyz or abc\\xyz
+    r"^(\.)$"              # just "."
+)  # yapf: disable
 
 logger = logging.getLogger(__name__)
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -127,7 +127,7 @@ header Pyflakes
 for d in b2sdk test *.py
 do
     # pyflakes does not ignore lines tagged with  # noqa
-    output="$(pyflakes "$d" | egrep -v "(b2sdk/v[0-9]+/(__init__|exception)\.py|test/v[0-9]+/deps(_exception)?.py):[0-9]+:[0-9]* ('from b2sdk.v[0-9]+(\.exception)? import \*' used; unable to detect undefined names|'(b2sdk\..*|\..*)' imported but unused)")"
+    output="$(pyflakes "$d" | egrep -v "(b2sdk/(v[0-9]|sync)+/(__init__|exception)\.py|test/(v[0-9]|sync)+/deps(_exception)?.py):[0-9]+:[0-9]* ('from b2sdk.(v[0-9]+|sync)(\.exception)? import \*' used; unable to detect undefined names|'(b2sdk\..*|\..*)' imported but unused)")"
 
     if [ -z "$output" ]
     then

--- a/test/sync/__init__.py
+++ b/test/sync/__init__.py
@@ -1,0 +1,9 @@
+######################################################################
+#
+# File: test/sync/__init__.py
+#
+# Copyright 2020 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################

--- a/test/sync/deps_exception.py
+++ b/test/sync/deps_exception.py
@@ -1,0 +1,11 @@
+######################################################################
+#
+# File: test/sync/deps_exception.py
+#
+# Copyright 2020 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from b2sdk.sync.exception import *

--- a/test/sync/test_base.py
+++ b/test/sync/test_base.py
@@ -1,0 +1,36 @@
+######################################################################
+#
+# File: test/sync/test_base.py
+#
+# Copyright 2020 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from contextlib import contextmanager
+import re
+import unittest
+
+
+class TestBase(unittest.TestCase):
+    @contextmanager
+    def assertRaises(self, exc, msg=None):
+        try:
+            yield
+        except exc as e:
+            if msg is not None:
+                if msg != str(e):
+                    assert False, "expected message '%s', but got '%s'" % (msg, str(e))
+        else:
+            assert False, 'should have thrown %s' % (exc,)
+
+    @contextmanager
+    def assertRaisesRegexp(self, expected_exception, expected_regexp):
+        try:
+            yield
+        except expected_exception as e:
+            if not re.search(expected_regexp, str(e)):
+                assert False, "expected message '%s', but got '%s'" % (expected_regexp, str(e))
+        else:
+            assert False, 'should have thrown %s' % (expected_exception,)

--- a/test/sync/test_exception.py
+++ b/test/sync/test_exception.py
@@ -44,4 +44,3 @@ export LANG=en_US.UTF-8""", str(e)
             raise UnSyncableFilename('message', 'filename')
         except UnSyncableFilename as e:
             assert str(e) == 'message: filename', str(e)
-

--- a/test/sync/test_exception.py
+++ b/test/sync/test_exception.py
@@ -16,8 +16,6 @@ from .deps_exception import (
     UnSyncableFilename,
 )
 
-import six
-
 
 class TestExceptions(TestBase):
     def test_environment_encoding_error(self):

--- a/test/sync/test_exception.py
+++ b/test/sync/test_exception.py
@@ -1,0 +1,49 @@
+######################################################################
+#
+# File: test/sync/test_exception.py
+#
+# Copyright 2020 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+from .test_base import TestBase
+
+from .deps_exception import (
+    EnvironmentEncodingError,
+    InvalidArgument,
+    IncompleteSync,
+    UnSyncableFilename,
+)
+
+import six
+
+
+class TestExceptions(TestBase):
+    def test_environment_encoding_error(self):
+        try:
+            raise EnvironmentEncodingError('fred', 'george')
+        except EnvironmentEncodingError as e:
+            assert str(e) == """file name fred cannot be decoded with system encoding (george).
+We think this is an environment error which you should workaround by
+setting your system encoding properly, for example like this:
+export LANG=en_US.UTF-8""", str(e)
+
+    def test_invalid_argument(self):
+        try:
+            raise InvalidArgument('param', 'message')
+        except InvalidArgument as e:
+            assert str(e) == 'param message', str(e)
+
+    def test_incomplete_sync(self):
+        try:
+            raise IncompleteSync()
+        except IncompleteSync as e:
+            assert str(e) == 'Incomplete sync: ', str(e)
+
+    def test_unsyncablefilename_error(self):
+        try:
+            raise UnSyncableFilename('message', 'filename')
+        except UnSyncableFilename as e:
+            assert str(e) == 'message: filename', str(e)
+

--- a/test/v1/deps_exception.py
+++ b/test/v1/deps_exception.py
@@ -8,4 +8,5 @@
 #
 ######################################################################
 
+from b2sdk.sync.exception import *
 from b2sdk.v1.exception import *

--- a/test/v1/test_sync.py
+++ b/test/v1/test_sync.py
@@ -22,6 +22,7 @@ from nose import SkipTest
 
 from enum import Enum
 
+from b2sdk.sync.exception import UnSyncableFilename
 from .test_base import TestBase
 
 from .deps_exception import DestFileNewer
@@ -475,6 +476,107 @@ class TestB2Folder(TestFolder):
         self.assertEqual(
             [], list(folder.all_files(self.reporter, policies_manager=polices_manager))
         )
+
+    def test_unsyncable_filenames(self):
+        b2_folder = B2Folder('bucket-name', '', self.api)
+
+        # Test a list of unsyncable file names
+        filenames_to_test = [
+            six.u('/'),  # absolute root path
+            six.u('//'),
+            six.u('///'),
+            six.u('/..'),
+            six.u('/../'),
+            six.u('/.../'),
+            six.u('/../.'),
+            six.u('/../..'),
+            six.u('/a.txt'),
+            six.u('/folder/a.txt'),
+            six.u('./folder/a.txt'),  # current dir relative path
+            six.u('folder/./a.txt'),
+            six.u('folder/folder/.'),
+            six.u('a//b/'),  # double-slashes
+            six.u('a///b'),
+            six.u('a////b'),
+            six.u('../test'),  # start with parent dir
+            six.u('../../test'),
+            six.u('../../abc/../test'),
+            six.u('../../abc/../test/'),
+            six.u('../../abc/../.test'),
+            six.u('a/b/c/../d'),  # parent dir embedded
+            six.u('a//..//b../..c/'),
+            six.u('..a/b../..c/../d..'),
+            six.u('a/../'),
+            six.u('a/../../../../../'),
+            six.u('a/b/c/..'),
+            six.u(r'\\'),  # backslash filenames
+            six.u(r'..\\'),
+            six.u(r'..\..'),
+            six.u(r'\..\\'),
+            six.u(r'\\..\\..'),
+            six.u(r'\\'),
+            six.u(r'\\\\'),
+            six.u(r'\\\\server\\share\\dir\\file'),
+            six.u(r'\\?\\C\\Drive\\temp'),
+            six.u(r'.\\//'),
+            six.u(r'..\\..//..\\\\'),
+            six.u(r'.\\a\\..\\b'),
+            six.u(r'a\\.\\b'),
+            six.u('Z:/windows/system32/drivers/etc/hosts'),
+            six.u('a:/Users/.default/test'),
+            six.u(r'C:\\Windows\\system32\\drivers\\mstsc.sys'),
+        ]
+
+        for filename in filenames_to_test:
+            self.bucket.ls.return_value = [
+                (
+                    FileVersionInfo(
+                        'a1', filename, 1, 'text/plain', 'sha1', {}, 1000, 'upload'
+                    ), ''
+                )
+            ]
+            try:
+                list(b2_folder.all_files(self.reporter))
+                self.fail("should have thrown UnSyncableFilename for: '%s'" % filename)
+            except UnSyncableFilename as e:
+                self.assertTrue(filename in str(e))
+
+    def test_syncable_filenames(self):
+        b2_folder = B2Folder('bucket-name', '', self.api)
+
+        # Test a list of syncable file names
+        filenames_to_test = [
+            six.u(''),
+            six.u(' '),
+            six.u(' / '),
+            six.u(' ./. '),
+            six.u(' ../.. '),
+            six.u('.. / ..'),
+            six.u(r'.. \ ..'),
+            six.u('file.txt'),
+            six.u('.folder/'),
+            six.u('..folder/'),
+            six.u('..file'),
+            six.u(r'file/ and\ folder'),
+            six.u('file..'),
+            six.u('..file..'),
+            six.u('folder/a.txt..'),
+            six.u('..a/b../c../..d/e../'),
+            six.u(r'folder\test'),
+            six.u(r'folder\..f..\..f\..f'),
+            six.u(r'mix/and\match/'),
+            six.u(r'a\b\c\d'),
+        ]
+
+        for filename in filenames_to_test:
+            self.bucket.ls.return_value = [
+                (
+                    FileVersionInfo(
+                        'a1', filename, 1, 'text/plain', 'sha1', {}, 1000, 'upload'
+                    ), ''
+                )
+            ]
+            list(b2_folder.all_files(self.reporter))
 
 
 class FakeFolder(AbstractFolder):

--- a/test/v1/test_sync.py
+++ b/test/v1/test_sync.py
@@ -22,10 +22,10 @@ from nose import SkipTest
 
 from enum import Enum
 
-from b2sdk.sync.exception import UnSyncableFilename
 from .test_base import TestBase
 
 from .deps_exception import DestFileNewer
+from .deps_exception import UnSyncableFilename
 from .deps import FileVersionInfo
 from .deps import AbstractFolder, B2Folder, LocalFolder
 from .deps import File, FileVersion
@@ -538,11 +538,7 @@ class TestB2Folder(TestFolder):
 
         for filename in filenames_to_test:
             self.bucket.ls.return_value = [
-                (
-                    FileVersionInfo(
-                        'a1', filename, 1, 'text/plain', 'sha1', {}, 1000, 'upload'
-                    ), ''
-                )
+                (FileVersionInfo('a1', filename, 1, 'text/plain', 'sha1', {}, 1000, 'upload'), '')
             ]
             try:
                 list(b2_folder.all_files(self.reporter))
@@ -583,11 +579,7 @@ class TestB2Folder(TestFolder):
 
         for filename in filenames_to_test:
             self.bucket.ls.return_value = [
-                (
-                    FileVersionInfo(
-                        'a1', filename, 1, 'text/plain', 'sha1', {}, 1000, 'upload'
-                    ), ''
-                )
+                (FileVersionInfo('a1', filename, 1, 'text/plain', 'sha1', {}, 1000, 'upload'), '')
             ]
             list(b2_folder.all_files(self.reporter))
 

--- a/test/v1/test_sync.py
+++ b/test/v1/test_sync.py
@@ -477,6 +477,13 @@ class TestB2Folder(TestFolder):
             [], list(folder.all_files(self.reporter, policies_manager=polices_manager))
         )
 
+    # Path names not allowed to be sync'd on Windows
+    NOT_SYNCD_ON_WINDOWS = [
+        six.u('Z:/windows/system32/drivers/etc/hosts'),
+        six.u('a:/Users/.default/test'),
+        six.u(r'C:\Windows\system32\drivers\mstsc.sys'),
+    ]
+
     def test_unsyncable_filenames(self):
         b2_folder = B2Folder('bucket-name', '', self.api)
 
@@ -510,6 +517,7 @@ class TestB2Folder(TestFolder):
             six.u('a/../../../../../'),
             six.u('a/b/c/..'),
             six.u(r'\\'),  # backslash filenames
+            six.u(r'\z'),
             six.u(r'..\\'),
             six.u(r'..\..'),
             six.u(r'\..\\'),
@@ -517,7 +525,8 @@ class TestB2Folder(TestFolder):
             six.u(r'\\'),
             six.u(r'\\\\'),
             six.u(r'\\\\server\\share\\dir\\file'),
-            six.u(r'\\?\\C\\Drive\\temp'),
+            six.u(r'\\server\share\dir\file'),
+            six.u(r'\\?\C\Drive\temp'),
             six.u(r'.\\//'),
             six.u(r'..\\..//..\\\\'),
             six.u(r'.\\a\\..\\b'),
@@ -525,13 +534,7 @@ class TestB2Folder(TestFolder):
         ]
 
         if platform.system() == "Windows":
-            filenames_to_test.extend(
-                [
-                    six.u('Z:/windows/system32/drivers/etc/hosts'),
-                    six.u('a:/Users/.default/test'),
-                    six.u(r'C:\\Windows\\system32\\drivers\\mstsc.sys'),
-                ]
-            )
+            filenames_to_test.extend(self.NOT_SYNCD_ON_WINDOWS)
 
         for filename in filenames_to_test:
             self.bucket.ls.return_value = [
@@ -573,6 +576,10 @@ class TestB2Folder(TestFolder):
             six.u(r'mix/and\match/'),
             six.u(r'a\b\c\d'),
         ]
+
+        # filenames not permitted on Windows *should* be allowed on Linux
+        if platform.system() != "Windows":
+            filenames_to_test.extend(self.NOT_SYNCD_ON_WINDOWS)
 
         for filename in filenames_to_test:
             self.bucket.ls.return_value = [

--- a/test/v1/test_sync.py
+++ b/test/v1/test_sync.py
@@ -522,10 +522,16 @@ class TestB2Folder(TestFolder):
             six.u(r'..\\..//..\\\\'),
             six.u(r'.\\a\\..\\b'),
             six.u(r'a\\.\\b'),
-            six.u('Z:/windows/system32/drivers/etc/hosts'),
-            six.u('a:/Users/.default/test'),
-            six.u(r'C:\\Windows\\system32\\drivers\\mstsc.sys'),
         ]
+
+        if platform.system() == "Windows":
+            filenames_to_test.extend(
+                [
+                    six.u('Z:/windows/system32/drivers/etc/hosts'),
+                    six.u('a:/Users/.default/test'),
+                    six.u(r'C:\\Windows\\system32\\drivers\\mstsc.sys'),
+                ]
+            )
 
         for filename in filenames_to_test:
             self.bucket.ls.return_value = [


### PR DESCRIPTION
The `sync` functionality suffered from a directory traversal attack due to the use of `os.path.join(root_path, file_name)` where the `file_name` could contain a relative path or absolute path outside the `root_path` specified.  This would allow an attacker to write files to arbitrary locations depending on the contents of the bucket being synchronized.

Solution is two-fold:
 1. Do not allow relative or absolute paths in b2 file names being synchronized
 2. Ensure all files written are within the specified root path