### PR TITLE
Fix unsyncable paths in local folder implementation

### DIFF
--- a/b2sdk/sync/folder.py
+++ b/b2sdk/sync/folder.py
@@ -146,11 +146,11 @@ class LocalFolder(AbstractFolder):
         :param file_name: a file name
         :type file_name: str
         """
-        # Setup the relative_path starting at self.root
-        relative_path = os.path.relpath(file_name.replace('/', os.path.sep), start=self.root)
+        # Fix OS path separators
+        file_name = file_name.replace('/', os.path.sep)
 
-        # Convert the relative path to an absolute path
-        full_path = os.path.abspath(relative_path)
+        # Generate the full path to the file
+        full_path = os.path.normpath(os.path.join(self.root, file_name))
 
         # Get the common prefix between the new full_path and self.root
         common_prefix = os.path.commonprefix([full_path, self.root])

--- a/b2sdk/v1/exception.py
+++ b/b2sdk/v1/exception.py
@@ -64,6 +64,7 @@ from b2sdk.exception import interpret_b2_error
 from b2sdk.sync.exception import EnvironmentEncodingError
 from b2sdk.sync.exception import IncompleteSync
 from b2sdk.sync.exception import InvalidArgument
+from b2sdk.sync.exception import UnSyncableFilename
 
 __all__ = (
     'AccountInfoError',
@@ -119,6 +120,7 @@ __all__ = (
     'UnknownError',
     'UnknownHost',
     'UnrecognizedBucketType',
+    'UnSyncableFilename',
     'UnsatisfiableRange',
     'UnusableFileName',
     'interpret_b2_error',

--- a/test/v1/deps_exception.py
+++ b/test/v1/deps_exception.py
@@ -8,5 +8,4 @@
 #
 ######################################################################
 
-from b2sdk.sync.exception import *
 from b2sdk.v1.exception import *

--- a/test/v1/test_sync.py
+++ b/test/v1/test_sync.py
@@ -349,6 +349,25 @@ class TestLocalFolder(TestFolder):
         else:
             self.assertEqual(self.NAMES, list(f.name for f in folder.all_files(self.reporter)))
 
+    def test_syncable_paths(self):
+        syncable_paths = (
+            (six.u('test.txt'), six.u('test.txt')), (six.u('./a/test.txt'), six.u('a/test.txt')),
+            (six.u('./a/../test.txt'), six.u('test.txt'))
+        )
+
+        folder = self.prepare_folder(prepare_files=False)
+        for syncable_path, norm_syncable_path in syncable_paths:
+            expected = os.path.join(self.root_dir, norm_syncable_path.replace('/', os.path.sep))
+            self.assertEqual(expected, folder.make_full_path(syncable_path))
+
+    def test_unsyncable_paths(self):
+        unsyncable_paths = (six.u('../test.txt'), six.u('a/../../test.txt'), six.u('/a/test.txt'))
+
+        folder = self.prepare_folder(prepare_files=False)
+        for unsyncable_path in unsyncable_paths:
+            with self.assertRaises(UnSyncableFilename):
+                folder.make_full_path(unsyncable_path)
+
 
 class TestB2Folder(TestFolder):
     __test__ = True


### PR DESCRIPTION
The bug was introduced in #125

For runs with prints added:
```
    def make_full_path(self, file_name):
        """
        Convert a file name into an absolute path, ensure it is not outside self.root
        :param file_name: a file name
        :type file_name: str
        """
        print(self.root, file_name)
        # Setup the relative_path starting at self.root
        relative_path = os.path.relpath(file_name.replace('/', os.path.sep), start=self.root)
        # Convert the relative path to an absolute path
        full_path = os.path.abspath(relative_path)
        print(relative_path, full_path)
        # ...
```
It doesn't work for relative source directories (the path is incorrect):
```
$ pwd
/home/maciek/Workspace/git/b2
$ b2 sync --delete test/ b2://ML-TestBucket/
(u'/home/maciek/Workspace/git/b2/test', u'test.txt')
(u'../test.txt', u'/home/maciek/Workspace/git/test.txt')
ERROR: illegal file name: /home/maciek/Workspace/git/test.txt
```
Only works if we sync the current dir:
```
$ pwd    
/home/maciek/Workspace/git/b2/test
$ b2 sync --delete ./ b2://ML-TestBucket/
(u'/home/maciek/Workspace/git/b2/test', u'test.txt')               
(u'test.txt', u'/home/maciek/Workspace/git/b2/test/test.txt')
upload test.txt
```