### PR TITLE
Fix upload part or file range on Python 2.7

### DIFF
--- a/b2sdk/download_dest.py
+++ b/b2sdk/download_dest.py
@@ -91,7 +91,7 @@ class DownloadDestLocalFile(AbstractDownloadDestination):
         completed = False
         try:
             # Open the file and let the caller write it.
-            with open(self.local_file_path, self.MODE) as f:
+            with io.open(self.local_file_path, self.MODE) as f:
                 yield f
 
             # After it's closed, set the mod time.

--- a/b2sdk/progress.py
+++ b/b2sdk/progress.py
@@ -55,6 +55,9 @@ class AbstractProgressListener(object):
         so far.  This is not a delta, it is the total number of bytes
         transferred so far.
 
+        Transfer can fail and restart from beginning so byte count can
+        decrease between calls.
+
         :param int byte_count: number of bytes have been transferred
         """
 

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -638,12 +638,13 @@ class BucketSimulator(object):
             contentSha1=sha1_sum
         )  # yapf: disable
 
-    def _simulate_chunked_post(self, stream, content_length, min_chunks=4, max_chunk_size=8096, simulate_retry=True):
+    def _simulate_chunked_post(
+        self, stream, content_length, min_chunks=4, max_chunk_size=8096, simulate_retry=True
+    ):
         chunk_size = max_chunk_size
         chunks_num = self._chunks_number(content_length, chunk_size)
         if chunks_num < min_chunks:
-            chunk_size = content_length // min_chunks
-        chunks_num = self._chunks_number(content_length, chunk_size)
+            chunk_size = max(content_length // min_chunks, 1)
         loop_count = 2 if simulate_retry else 1
         stream_data = None
         for i in range(loop_count):
@@ -663,7 +664,7 @@ class BucketSimulator(object):
     def _chunks_number(self, content_length, chunk_size):
         chunks_number = content_length // chunk_size
         if content_length % chunk_size > 0:
-            chunks_number + 1
+            chunks_number = chunks_number + 1
         return chunks_number
 
     def _next_file_id(self):

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -600,7 +600,7 @@ class BucketSimulator(object):
         self, upload_id, upload_auth_token, file_name, content_length, content_type, content_sha1,
         file_infos, data_stream
     ):
-        data_bytes = data_stream.read()
+        data_bytes = self._simulate_chunked_post(data_stream, content_length)
         assert len(data_bytes) == content_length
         if content_sha1 == HEX_DIGITS_AT_END:
             content_sha1 = data_bytes[-40:].decode()
@@ -620,7 +620,7 @@ class BucketSimulator(object):
 
     def upload_part(self, file_id, part_number, content_length, sha1_sum, input_stream):
         file_sim = self.file_id_to_file[file_id]
-        part_data = input_stream.read()
+        part_data = self._simulate_chunked_post(input_stream, content_length)
         assert len(part_data) == content_length
         if sha1_sum == HEX_DIGITS_AT_END:
             sha1_sum = part_data[-40:].decode()
@@ -637,6 +637,34 @@ class BucketSimulator(object):
             contentLength=content_length,
             contentSha1=sha1_sum
         )  # yapf: disable
+
+    def _simulate_chunked_post(self, stream, content_length, min_chunks=4, max_chunk_size=8096, simulate_retry=True):
+        chunk_size = max_chunk_size
+        chunks_num = self._chunks_number(content_length, chunk_size)
+        if chunks_num < min_chunks:
+            chunk_size = content_length // min_chunks
+        chunks_num = self._chunks_number(content_length, chunk_size)
+        loop_count = 2 if simulate_retry else 1
+        stream_data = None
+        for i in range(loop_count):
+            chunks = []
+            stream.seek(0)  # we always do this in `do_post` in `b2http` so we want it here *always*
+            while True:
+                data = stream.read(chunk_size)
+                chunks.append(data)
+                if not data:
+                    break
+            _stream_data = b''.join(chunks)
+            if stream_data is not None:
+                assert _stream_data == stream_data
+            stream_data = _stream_data
+        return stream_data
+
+    def _chunks_number(self, content_length, chunk_size):
+        chunks_number = content_length // chunk_size
+        if content_length % chunk_size > 0:
+            chunks_number + 1
+        return chunks_number
 
     def _next_file_id(self):
         return str(six.next(self.file_id_counter))

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -647,7 +647,7 @@ class BucketSimulator(object):
             chunk_size = max(content_length // min_chunks, 1)
         loop_count = 2 if simulate_retry else 1
         stream_data = None
-        for i in range(loop_count):
+        for _ in range(loop_count):
             chunks = []
             stream.seek(0)  # we always do this in `do_post` in `b2http` so we want it here *always*
             while True:

--- a/b2sdk/stream/progress.py
+++ b/b2sdk/stream/progress.py
@@ -32,6 +32,11 @@ class AbstractStreamWithProgress(StreamWrapper):
         self.bytes_completed = 0
         self.offset = offset
 
+    def seek(self, pos, whence=0):
+        pos = super(AbstractStreamWithProgress, self).seek(pos, whence=whence)
+        self.bytes_completed = pos
+        return pos
+
     def _progress_update(self, delta):
         self.bytes_completed += delta
         self.progress_listener.bytes_completed(self.bytes_completed + self.offset)

--- a/b2sdk/transfer/outbound/upload_manager.py
+++ b/b2sdk/transfer/outbound/upload_manager.py
@@ -158,18 +158,17 @@ class UploadManager(object):
             try:
                 with part_upload_source.open() as part_stream:
                     content_length = part_upload_source.get_content_length()
-                    input_stream = ReadingStreamWithProgress(part_stream, part_progress_listener, length=content_length)
+                    input_stream = ReadingStreamWithProgress(
+                        part_stream, part_progress_listener, length=content_length
+                    )
                     if part_upload_source.is_sha1_known():
                         content_sha1 = part_upload_source.get_content_sha1()
                     else:
-                        input_stream = StreamWithHash(
-                            input_stream, stream_length=content_length
-                        )
+                        input_stream = StreamWithHash(input_stream, stream_length=content_length)
                         content_sha1 = HEX_DIGITS_AT_END
                     # it is important that `len()` works on `input_stream`
                     response = self.services.session.upload_part(
-                        file_id, part_number, len(input_stream), content_sha1,
-                        input_stream
+                        file_id, part_number, len(input_stream), content_sha1, input_stream
                     )
                     if content_sha1 == HEX_DIGITS_AT_END:
                         content_sha1 = input_stream.hash
@@ -195,16 +194,20 @@ class UploadManager(object):
             for _ in six.moves.xrange(self.MAX_UPLOAD_ATTEMPTS):
                 try:
                     with upload_source.open() as file:
-                        input_stream = ReadingStreamWithProgress(file, progress_listener, length=content_length)
+                        input_stream = ReadingStreamWithProgress(
+                            file, progress_listener, length=content_length
+                        )
                         if upload_source.is_sha1_known():
                             content_sha1 = upload_source.get_content_sha1()
                         else:
-                            input_stream = StreamWithHash(input_stream, stream_length=content_length)
+                            input_stream = StreamWithHash(
+                                input_stream, stream_length=content_length
+                            )
                             content_sha1 = HEX_DIGITS_AT_END
                         # it is important that `len()` works on `input_stream`
                         response = self.services.session.upload_file(
-                            bucket_id, file_name, len(input_stream), content_type,
-                            content_sha1, file_info, input_stream
+                            bucket_id, file_name, len(input_stream), content_type, content_sha1,
+                            file_info, input_stream
                         )
                         if content_sha1 == HEX_DIGITS_AT_END:
                             content_sha1 = input_stream.hash

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -106,7 +106,7 @@ class UploadSourceLocalFile(AbstractUploadSource):
         return self.content_sha1
 
     def open(self):
-        return open(self.local_path, 'rb')
+        return io.open(self.local_path, 'rb')
 
     def _hex_sha1_of_file(self, local_path):
         with self.open() as f:

--- a/run-single-unit-test.sh
+++ b/run-single-unit-test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+python setup.py nosetests -a "__name__=$1" --processes=0 -s

--- a/test/v0/test_bucket.py
+++ b/test/v0/test_bucket.py
@@ -77,12 +77,17 @@ class StubProgressListener(AbstractProgressListener):
         self.history.append('%d:' % (total_byte_count,))
 
     def bytes_completed(self, byte_count):
-        assert byte_count >= self.last_byte_count
         self.last_byte_count = byte_count
         self.history.append(str(byte_count))
 
-    def is_valid(self):
-        return self.total == self.last_byte_count
+    def is_valid(self, check_closed=True, check_progress=True):
+        if self.total != self.last_byte_count:
+            return False
+        if check_closed and self.history[-1] != 'closed':
+            return False
+        if check_progress and len(self.history[1:-1]) < 2:
+            return False
+        return True
 
     def close(self):
         self.history.append('closed')
@@ -410,7 +415,7 @@ class TestUpload(TestCaseWithBucket):
         data = six.b('hello world')
         progress_listener = StubProgressListener()
         self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
-        self.assertEqual("11: 11 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_local_file(self):
         with TempDir() as d:
@@ -462,7 +467,7 @@ class TestUpload(TestCaseWithBucket):
         progress_listener = StubProgressListener()
         self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -473,7 +478,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_no_parts(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -483,7 +488,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertNotEqual(large_file_id, file_info.id_)  # it's not a match if there are no parts
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_all_parts_there(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -496,7 +501,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_part_does_not_match(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -507,7 +512,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertNotEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_wrong_part_size(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -518,7 +523,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertNotEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_file_info(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -531,7 +536,7 @@ class TestUpload(TestCaseWithBucket):
         )
         self.assertEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_file_info_does_not_match(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -544,7 +549,7 @@ class TestUpload(TestCaseWithBucket):
         )
         self.assertNotEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def _start_large_file(self, file_name, file_info=None):
         if file_info is None:
@@ -601,7 +606,7 @@ class DownloadTests(object):
     def _verify(self, expected_result, check_progress_listener=True):
         assert self.download_dest.get_bytes_written() == six.b(expected_result)
         if check_progress_listener:
-            assert self.progress_listener.is_valid()
+            assert self.progress_listener.is_valid(check_closed=False, check_progress=False)
 
     def test_download_by_id_no_progress(self):
         self.bucket.download_file_by_id(self.file_info.id_, self.download_dest)

--- a/test/v1/test_bucket.py
+++ b/test/v1/test_bucket.py
@@ -565,6 +565,14 @@ class TestUpload(TestCaseWithBucket):
         self._check_file_contents('file1', data)
         self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
 
+    def test_upload_local_large_file(self):
+        with TempDir() as d:
+            path = os.path.join(d, 'file1')
+            data = self._make_data(self.simulator.MIN_PART_SIZE * 3)
+            write_file(path, data)
+            self.bucket.upload_local_file(path, 'file1')
+            self._check_file_contents('file1', data)
+
     def test_upload_large_resume(self):
         part_size = self.simulator.MIN_PART_SIZE
         data = self._make_data(part_size * 3)

--- a/test/v1/test_bucket.py
+++ b/test/v1/test_bucket.py
@@ -79,12 +79,17 @@ class StubProgressListener(AbstractProgressListener):
         self.history.append('%d:' % (total_byte_count,))
 
     def bytes_completed(self, byte_count):
-        assert byte_count >= self.last_byte_count
         self.last_byte_count = byte_count
         self.history.append(str(byte_count))
 
-    def is_valid(self):
-        return self.total == self.last_byte_count
+    def is_valid(self, check_closed=True, check_progress=True):
+        if self.total != self.last_byte_count:
+            return False
+        if check_closed and self.history[-1] != 'closed':
+            return False
+        if check_progress and len(self.history[1:-1]) < 2:
+            return False
+        return True
 
     def close(self):
         self.history.append('closed')
@@ -496,7 +501,7 @@ class TestUpload(TestCaseWithBucket):
         data = six.b('hello world')
         progress_listener = StubProgressListener()
         self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
-        self.assertEqual("11: 11 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_local_file(self):
         with TempDir() as d:
@@ -563,7 +568,7 @@ class TestUpload(TestCaseWithBucket):
         progress_listener = StubProgressListener()
         self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_local_large_file(self):
         with TempDir() as d:
@@ -582,7 +587,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_no_parts(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -592,7 +597,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertNotEqual(large_file_id, file_info.id_)  # it's not a match if there are no parts
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_all_parts_there(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -605,7 +610,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_part_does_not_match(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -616,7 +621,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertNotEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_wrong_part_size(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -627,7 +632,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self.assertNotEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_file_info(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -640,7 +645,7 @@ class TestUpload(TestCaseWithBucket):
         )
         self.assertEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_resume_file_info_does_not_match(self):
         part_size = self.simulator.MIN_PART_SIZE
@@ -653,7 +658,7 @@ class TestUpload(TestCaseWithBucket):
         )
         self.assertNotEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def test_upload_large_file_with_restricted_api_key(self):
         self.simulator.key_id_to_key[self.account_id].name_prefix_or_none = 'path/to'
@@ -665,7 +670,7 @@ class TestUpload(TestCaseWithBucket):
         )
         self.assertEqual(len(data), file_info.size)
         self._check_file_contents('path/to/file1', data)
-        self.assertEqual("600: 200 400 600 closed", progress_listener.get_history())
+        self.assertTrue(progress_listener.is_valid())
 
     def _start_large_file(self, file_name, file_info=None):
         if file_info is None:
@@ -722,7 +727,7 @@ class DownloadTests(object):
     def _verify(self, expected_result, check_progress_listener=True):
         assert self.download_dest.get_bytes_written() == six.b(expected_result)
         if check_progress_listener:
-            assert self.progress_listener.is_valid()
+            assert self.progress_listener.is_valid(check_closed=False, check_progress=False)
 
     def test_download_by_id_no_progress(self):
         self.bucket.download_file_by_id(self.file_info.id_, self.download_dest)


### PR DESCRIPTION
Python 2.7 `open()` is returning object with
`seek()` implementation returning `None`.

Fixed it with using `io.open()` for file upload source.
Added simulation of chunked read with retry in RawSimulator for uploading,
because all streams have to support seeking to beginning after reading
entire stream.

Resolves Backblaze/B2_Command_Line_Tool#639