### PR TITLE
Fix WritingStreamWithProgress

### DIFF
--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -307,7 +307,9 @@ class FakeResponse(object):
 
     def iter_content(self, chunk_size=1):
         start = 0
+        rnd = random.Random(self.url)
         while start <= len(self.data_bytes):
+            time.sleep(rnd.random() * 0.01)
             yield self.data_bytes[start:start + chunk_size]
             start += chunk_size
 

--- a/b2sdk/stream/progress.py
+++ b/b2sdk/stream/progress.py
@@ -60,6 +60,12 @@ class ReadingStreamWithProgress(AbstractStreamWithProgress):
 
     def seek(self, pos, whence=0):
         pos = super(ReadingStreamWithProgress, self).seek(pos, whence=whence)
+        # reset progress to current stream position - assumption is that ReadingStreamWithProgress would not be used
+        # for random access streams, and seek is only used to reset stream to beginning to retry file upload
+        # and multipart file upload would open and use different file descriptor for each part;
+        # this logic cannot be used for WritingStreamWithProgress because multipart download has to use
+        # single file descriptor and synchronize writes so seeking cannot be understood there as progress reset
+        # and writing  progress is always monotonic
         self.bytes_completed = pos
         return pos
 

--- a/b2sdk/stream/progress.py
+++ b/b2sdk/stream/progress.py
@@ -32,11 +32,6 @@ class AbstractStreamWithProgress(StreamWrapper):
         self.bytes_completed = 0
         self.offset = offset
 
-    def seek(self, pos, whence=0):
-        pos = super(AbstractStreamWithProgress, self).seek(pos, whence=whence)
-        self.bytes_completed = pos
-        return pos
-
     def _progress_update(self, delta):
         self.bytes_completed += delta
         self.progress_listener.bytes_completed(self.bytes_completed + self.offset)
@@ -62,6 +57,11 @@ class ReadingStreamWithProgress(AbstractStreamWithProgress):
         data = super(ReadingStreamWithProgress, self).read(size)
         self._progress_update(len(data))
         return data
+
+    def seek(self, pos, whence=0):
+        pos = super(AbstractStreamWithProgress, self).seek(pos, whence=whence)
+        self.bytes_completed = pos
+        return pos
 
     def __len__(self):
         return self.length

--- a/b2sdk/stream/progress.py
+++ b/b2sdk/stream/progress.py
@@ -59,7 +59,7 @@ class ReadingStreamWithProgress(AbstractStreamWithProgress):
         return data
 
     def seek(self, pos, whence=0):
-        pos = super(AbstractStreamWithProgress, self).seek(pos, whence=whence)
+        pos = super(ReadingStreamWithProgress, self).seek(pos, whence=whence)
         self.bytes_completed = pos
         return pos
 

--- a/test/v0/test_bucket.py
+++ b/test/v0/test_bucket.py
@@ -80,14 +80,30 @@ class StubProgressListener(AbstractProgressListener):
         self.last_byte_count = byte_count
         self.history.append(str(byte_count))
 
-    def is_valid(self, check_closed=True, check_progress=True):
+    def is_valid(self, **kwargs):
+        valid, _ = self.is_valid_reason(**kwargs)
+        return valid
+
+    def is_valid_reason(self, check_closed=True, check_progress=True, check_monotonic_progress=False):
+        progress_end = -1
+        if self.history[progress_end] == 'closed':
+            progress_end = -2
+
+        # self.total != self.last_byte_count may be a consequence of non-monotonic
+        # progress, so we want to check this first
+        if check_monotonic_progress:
+            prev = 0
+            for val in map(int, self.history[1:progress_end]):
+                if val < prev:
+                    return False, 'non-monotonic progress'
+                prev = val
         if self.total != self.last_byte_count:
-            return False
+            return False, 'total different than last_byte_count'
         if check_closed and self.history[-1] != 'closed':
-            return False
-        if check_progress and len(self.history[1:-1]) < 2:
-            return False
-        return True
+            return False, 'no "closed" at the end of history'
+        if check_progress and len(self.history[1:progress_end]) < 2:
+            return False, 'progress in history has less than 2 entries'
+        return True, ''
 
     def close(self):
         self.history.append('closed')
@@ -606,7 +622,12 @@ class DownloadTests(object):
     def _verify(self, expected_result, check_progress_listener=True):
         assert self.download_dest.get_bytes_written() == six.b(expected_result)
         if check_progress_listener:
-            assert self.progress_listener.is_valid(check_closed=False, check_progress=False)
+            valid, reason = self.progress_listener.is_valid_reason(
+                check_closed=False,
+                check_progress=False,
+                check_monotonic_progress=True,
+            )
+            assert valid, reason
 
     def test_download_by_id_no_progress(self):
         self.bucket.download_file_by_id(self.file_info.id_, self.download_dest)

--- a/test/v1/test_bucket.py
+++ b/test/v1/test_bucket.py
@@ -731,7 +731,7 @@ class TestUpload(TestCaseWithBucket):
 # Downloads
 
 class DownloadTestsBase(object):
-    DATA = ''
+    DATA = NotImplemented
 
     def setUp(self):
         super(DownloadTestsBase, self).setUp()


### PR DESCRIPTION
Remove `seek()` progress updating logic - writes can happen
in different parts of file.

Fix tests to reliably check for non-monotonic download progress