### PR TITLE
Allow specifying custom realm in B2Session.authorize_account

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ b2sdk>=0.0.0,<1.0.0
 
 ## Not released yet
 
-* nothing yet for the next release
+* Allow specifying custom realm in B2Session.authorize_account
 
 ## 1.1.2 (2020-07-06)
 

--- a/b2sdk/account_info/abstract.py
+++ b/b2sdk/account_info/abstract.py
@@ -19,7 +19,8 @@ from b2sdk.utils import B2TraceMetaAbstract, limit_trace_arguments
 @six.add_metaclass(B2TraceMetaAbstract)
 class AbstractAccountInfo(object):
     """
-    Abstract class for a holder for all account-related information that needs to be kept between API calls and between invocations of the program.
+    Abstract class for a holder for all account-related information
+    that needs to be kept between API calls and between invocations of the program.
 
     This includes: account ID, application key ID, application key,
     auth tokens, API URL, download URL, and uploads URLs.

--- a/b2sdk/session.py
+++ b/b2sdk/session.py
@@ -108,7 +108,7 @@ class B2Session(object):
             self.cache.clear()
 
         # Authorize
-        realm_url = self.account_info.REALM_URLS[realm]
+        realm_url = self.account_info.REALM_URLS.get(realm, realm)
         response = self.raw_api.authorize_account(realm_url, application_key_id, application_key)
         allowed = response['allowed']
 

--- a/test/v0/test_bucket.py
+++ b/test/v0/test_bucket.py
@@ -84,7 +84,9 @@ class StubProgressListener(AbstractProgressListener):
         valid, _ = self.is_valid_reason(**kwargs)
         return valid
 
-    def is_valid_reason(self, check_closed=True, check_progress=True, check_monotonic_progress=False):
+    def is_valid_reason(
+        self, check_closed=True, check_progress=True, check_monotonic_progress=False
+    ):
         progress_end = -1
         if self.history[progress_end] == 'closed':
             progress_end = -2

--- a/test/v1/test_bucket.py
+++ b/test/v1/test_bucket.py
@@ -86,7 +86,9 @@ class StubProgressListener(AbstractProgressListener):
         valid, _ = self.is_valid_reason(**kwargs)
         return valid
 
-    def is_valid_reason(self, check_closed=True, check_progress=True, check_monotonic_progress=False):
+    def is_valid_reason(
+        self, check_closed=True, check_progress=True, check_monotonic_progress=False
+    ):
         progress_end = -1
         if self.history[progress_end] == 'closed':
             progress_end = -2
@@ -730,6 +732,7 @@ class TestUpload(TestCaseWithBucket):
 
 # Downloads
 
+
 class DownloadTestsBase(object):
     DATA = NotImplemented
 
@@ -918,6 +921,7 @@ class TestDownloadParallelALotOfStreams(DownloadTestsBase, TestCaseWithBucket):
             self.file_info.id_, self.download_dest, self.progress_listener
         )
         self._verify(self.DATA)
+
 
 # Truncated downloads
 


### PR DESCRIPTION
Fixes Backblaze/B2_Command_Line_Tool#642

The test code has been changed because of missing autoformatting in some of the previous commits.