### PR TITLE
Fix missing SyncReport import in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Add custom exception for `403 transaction_cap_exceeded`
 
+### Changed
+* Fix missing import in the synchronization example
+
 ## [1.2.0] - 2020-11-03
 
 ### Added

--- a/doc/source/quick_start.rst
+++ b/doc/source/quick_start.rst
@@ -30,6 +30,7 @@ Synchronization
     >>> from b2sdk.v1 import ScanPoliciesManager
     >>> from b2sdk.v1 import parse_sync_folder
     >>> from b2sdk.v1 import Synchronizer
+    >>> from b2sdk.v1 import SyncReport
     >>> import time
     >>> import sys
 


### PR DESCRIPTION
Quick documentation fix.

The synchronization example in the [documentation](https://b2-sdk-python.readthedocs.io/en/master/quick_start.html?highlight=SyncReport#synchronization) uses the `SyncReport` class but it's not imported so this can't work.