### PR TITLE
disable decompression on download (with content-encoding=gzip header)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add custom exception for `403 transaction_cap_exceeded`
 * Add `get_file_info_by_id` and `get_file_info_by_name` to `Bucket`
 * `FileNotPresent` and `NonExistentBucket` now subclass new exceptions `FileOrBucketNotFound` and `ResourceNotFound`
+* Add and use `B2Response` class to avoid decompressing on download when `content-encoding=gzip` header is present
 
 ### Changed
 * Fix missing import in the synchronization example

--- a/b2sdk/b2http.py
+++ b/b2sdk/b2http.py
@@ -19,6 +19,7 @@ import time
 
 from typing import Any, Dict
 
+from .b2response import B2Response
 from .exception import (
     B2Error, B2RequestTimeoutDuringUpload, BadDateFormat, BrokenPipe, B2ConnectionError,
     B2RequestTimeout, ClockSkew, ConnectionReset, interpret_b2_error, UnknownError, UnknownHost
@@ -375,6 +376,8 @@ class B2Http(object):
             response = self.session.get(
                 url, headers=request_headers, stream=True, timeout=self.TIMEOUT
             )
+            # cast response to B2Response so we can override iter_content()
+            response.__class__ = B2Response
             self._run_post_request_hooks('GET', url, request_headers, response)
             return response
 

--- a/b2sdk/b2response.py
+++ b/b2sdk/b2response.py
@@ -1,0 +1,72 @@
+from requests.exceptions import ChunkedEncodingError, ContentDecodingError, StreamConsumedError
+from requests.models import Response
+from requests.utils import iter_slices, stream_decode_response_unicode
+from urllib3.exceptions import ProtocolError, DecodeError, ReadTimeoutError
+
+
+class B2Response(Response):
+    """
+    Child class of 'Response' from module 'Requests.'
+
+    Overrides method 'iter_content' to set 'decode_content' to 'False'
+    in the call to self.raw.stream() in order to avoid decompressing files
+    that have been uploaded with 'b2-content-encoding=gzip'. Up-to-date with
+    v2.25.1 of Requests library (2020-12-16).
+    """
+
+    def iter_content(self, chunk_size=1, decode_unicode=False):
+        """Iterates over the response data.  When stream=True is set on the
+        request, this avoids reading the content at once into memory for
+        large responses.  The chunk size is the number of bytes it should
+        read into memory.  This is not necessarily the length of each item
+        returned as decoding can take place.
+
+        chunk_size must be of type int or None. A value of None will
+        function differently depending on the value of `stream`.
+        stream=True will read data as it arrives in whatever size the
+        chunks are received. If stream=False, data is returned as
+        a single chunk.
+
+        If decode_unicode is True, content will be decoded using the best
+        available encoding based on the response.
+        """
+
+        def generate():
+            # Special case for urllib3.
+            if hasattr(self.raw, 'stream'):
+                try:
+                    # set decode_content to False to prevent decompressing files that
+                    # have been uploaded with b2-content-encoding=gzip
+                    for chunk in self.raw.stream(chunk_size, decode_content=False):
+                        yield chunk
+                except ProtocolError as e:
+                    raise ChunkedEncodingError(e)
+                except DecodeError as e:
+                    raise ContentDecodingError(e)
+                except ReadTimeoutError as e:
+                    raise ConnectiоnError(e)
+            else:
+                # Standard file-like object.
+                while True:
+                    chunk = self.raw.read(chunk_size)
+                    if not chunk:
+                        break
+                    yield chunk
+
+            self._content_consumed = True
+
+        if self._content_consumed and isinstance(self._content, bool):
+            raise StreamConsumedError()
+        elif chunk_size is not None and not isinstance(chunk_size, int):
+            raise TypeError("chunk_size must be an int, it is instead a %s." % type(chunk_size))
+        # simulate reading small chunks of the content
+        reused_chunks = iter_slices(self._content, chunk_size)
+
+        stream_chunks = generate()
+
+        chunks = reused_chunks if self._content_consumed else stream_chunks
+
+        if decode_unicode:
+            chunks = stream_decode_response_unicode(chunks, self)
+
+        return chunks

--- a/b2sdk/b2response.py
+++ b/b2sdk/b2response.py
@@ -1,3 +1,13 @@
+######################################################################
+#
+# File: b2sdk/b2response.py
+#
+# Copyright 2020 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
 from requests.exceptions import ChunkedEncodingError, ContentDecodingError, ConnectionError, StreamConsumedError
 from requests.models import Response
 from requests.utils import iter_slices, stream_decode_response_unicode

--- a/b2sdk/b2response.py
+++ b/b2sdk/b2response.py
@@ -1,4 +1,4 @@
-from requests.exceptions import ChunkedEncodingError, ContentDecodingError, StreamConsumedError
+from requests.exceptions import ChunkedEncodingError, ContentDecodingError, ConnectionError, StreamConsumedError
 from requests.models import Response
 from requests.utils import iter_slices, stream_decode_response_unicode
 from urllib3.exceptions import ProtocolError, DecodeError, ReadTimeoutError
@@ -44,7 +44,7 @@ class B2Response(Response):
                 except DecodeError as e:
                     raise ContentDecodingError(e)
                 except ReadTimeoutError as e:
-                    raise ConnectiоnError(e)
+                    raise ConnectionError(e)
             else:
                 # Standard file-like object.
                 while True:

--- a/b2sdk/raw_api.py
+++ b/b2sdk/raw_api.py
@@ -961,6 +961,30 @@ def test_raw_api_helper(raw_api):
     )
     assert info_headers['x-bz-file-id'] == file_id
 
+    # b2_upload_file with b2-content-encoding=gzip
+    print('b2_upload_file (b2-content-encoding=gzip)')
+    file_name = 'test.txt'
+    file_contents = b'hello world'
+    file_sha1 = hex_sha1_of_stream(io.BytesIO(file_contents), len(file_contents))
+    file_dict = raw_api.upload_file(
+        upload_url,
+        upload_auth_token,
+        file_name,
+        len(file_contents),
+        'text/plain',
+        file_sha1,
+        {'b2-content-encoding': 'gzip'},
+        io.BytesIO(file_contents),
+    )
+    file_id = file_dict['fileId']
+
+    # b2_download_file_by_id with content-encoding=gzip
+    print('b2_download_file_by_id (content-encoding=gzip)')
+    url = raw_api.get_download_url_by_id(download_url, file_id)
+    with raw_api.download_file_from_url(account_auth_token, url) as response:
+        data = next(response.iter_content(chunk_size=len(file_contents)))
+        assert data == file_contents, data
+
     # b2_hide_file
     print('b2_hide_file')
     raw_api.hide_file(api_url, account_auth_token, bucket_id, file_name)


### PR DESCRIPTION
Create a B2Response subclass that inherits from Response and override iter_content() to set decode_content=False in call to raw.stream(). Use B2Response for downloads so that when files are uploaded with b2-content-encoding=gzip, the client doesn't decompress the uploaded data.