### PR TITLE
If content SHA1 is provided, populate it in file info as large_file_sha1 for large files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Fix missing import in the synchronization example
+* Populate `large_file_sha1` file info for large files when SHA1 is provided
 
 ## [1.2.0] - 2020-11-03
 

--- a/b2sdk/transfer/emerge/emerger.py
+++ b/b2sdk/transfer/emerge/emerger.py
@@ -63,10 +63,12 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         """
         planner = self.get_emerge_planner(recommended_upload_part_size=recommended_upload_part_size)
         emerge_plan = planner.get_emerge_plan(write_intents)
-        if emerge_plan.is_large_file() and 'large_file_sha1' not in file_info:
+        if emerge_plan.is_large_file():
             [write_intent] = write_intents
             if write_intent.outbound_source.is_sha1_known():
-                file_info['large_file_sha1'] = write_intent.outbound_source.get_content_sha1()
+                file_info = file_info or {}
+                if 'large_file_sha1' not in file_info:
+                    file_info['large_file_sha1'] = write_intent.outbound_source.get_content_sha1()
         return self.emerge_executor.execute_emerge_plan(
             emerge_plan,
             bucket_id,

--- a/b2sdk/transfer/emerge/emerger.py
+++ b/b2sdk/transfer/emerge/emerger.py
@@ -63,6 +63,10 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         """
         planner = self.get_emerge_planner(recommended_upload_part_size=recommended_upload_part_size)
         emerge_plan = planner.get_emerge_plan(write_intents)
+        if emerge_plan.is_large_file() and 'large_file_sha1' not in file_info:
+            [write_intent] = write_intents
+            if write_intent.outbound_source.is_sha1_known():
+                file_info['large_file_sha1'] = write_intent.outbound_source.get_content_sha1()
         return self.emerge_executor.execute_emerge_plan(
             emerge_plan,
             bucket_id,
@@ -98,6 +102,10 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         """
         planner = self.get_emerge_planner(recommended_upload_part_size=recommended_upload_part_size)
         emerge_plan = planner.get_streaming_emerge_plan(write_intent_iterator)
+        if emerge_plan.is_large_file() and 'large_file_sha1' not in file_info:
+            [write_intent] = write_intents
+            if write_intent.outbound_source.is_sha1_known():
+                file_info['large_file_sha1'] = write_intent.outbound_source.get_content_sha1()
         return self.emerge_executor.execute_emerge_plan(
             emerge_plan,
             bucket_id,

--- a/b2sdk/transfer/emerge/emerger.py
+++ b/b2sdk/transfer/emerge/emerger.py
@@ -102,10 +102,6 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         """
         planner = self.get_emerge_planner(recommended_upload_part_size=recommended_upload_part_size)
         emerge_plan = planner.get_streaming_emerge_plan(write_intent_iterator)
-        if emerge_plan.is_large_file() and 'large_file_sha1' not in file_info:
-            [write_intent] = write_intents
-            if write_intent.outbound_source.is_sha1_known():
-                file_info['large_file_sha1'] = write_intent.outbound_source.get_content_sha1()
         return self.emerge_executor.execute_emerge_plan(
             emerge_plan,
             bucket_id,


### PR DESCRIPTION
B2 does not provide the contentSha1 value for large files, instead returning "none". This can cause confusion for many users [1], and the fact that the B2 CLI does not populate the large_file_sha1 file info entry is arguably a bug.

This implementation only adds the large_file_sha1 file info entry if it is not already present, and the content SHA1 is known in advance (i.e. it will not cause a SHA1 to be computed if it is not provided). This works with B2 CLI when specifying the "--sha1" option, which without this, would silently swallow the provided SHA1, which the user would likely not notice until _after_ the potentially lengthy upload was complete.

In addition, this implementation only applies for `emerge`, not `emerge_stream`, since it's not clear to me where the known SHA1 would be, assuming it were provided.
    
[1] https://github.com/Backblaze/B2_Command_Line_Tool/issues/604