### PR TITLE
add __slots__ and __eq__ to FileVersionInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Add `__slots__` and `__eq__` to `FileVersionInfo` for memory usage optimization and ease of testing
+
 ### Fixed
 * Fix clearing cache during `authorize_account`
 * Fix `ChainedStream` (needed in `Bucket.create_file` etc.)

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -107,10 +107,9 @@ class FileVersionInfo(object):
         return cls.LS_ENTRY_TEMPLATE % ('-', '-', '-', '-', 0, name)
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
+        sentry = object()
         for attr in self.__slots__:
-            if getattr(self, attr) != getattr(other, attr):
+            if getattr(self, attr) != getattr(other, attr, sentry):
                 return False
         return True
 

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -34,6 +34,11 @@ class FileVersionInfo(object):
     """
     LS_ENTRY_TEMPLATE = '%83s  %6s  %10s  %8s  %9d  %s'  # order is file_id, action, date, time, size, name
 
+    __slots__ = [
+        'id_', 'file_name', 'size', 'content_type', 'content_sha1', 'content_md5', 'file_info',
+        'upload_timestamp', 'action', 'server_side_encryption'
+    ]
+
     def __init__(
         self,
         id_,
@@ -100,6 +105,14 @@ class FileVersionInfo(object):
     def format_folder_ls_entry(cls, name):
         """ legacy method, to be removed in v2: formats a `ls` "folder" consistently with format_ls_entry() """
         return cls.LS_ENTRY_TEMPLATE % ('-', '-', '-', '-', 0, name)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        for attr in self.__slots__:
+            if getattr(self, attr) != getattr(other, attr):
+                return False
+        return True
 
 
 class FileVersionInfoFactory(object):


### PR DESCRIPTION
reduce memory footprint of `FileVersionInfo` in preparation for SSE-C sync support needing to reference a full object if there is a chance that `SyncEncryptionSettingProvider` may need to read it