### PR TITLE
remove Bucket.start_large_file and deprecated Bucket.copy_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `b2sdk.v1.sync` refactored to reflect `b2sdk.sync` structure
 * Make `B2Api.get_bucket_by_id` return populated bucket objects in v2
 
+### Removed
+* Remove `Bucket.copy_file` and `Bucket.start_large_file` 
+
 ## [1.7.0] - 2021-04-22
 
 ### Added

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -391,19 +391,6 @@ class Bucket(metaclass=B2TraceMeta):
             prefix=prefix,
         )
 
-    def start_large_file(self, file_name, content_type=None, file_info=None):
-        """
-        Start a large file transfer.
-
-        :param str file_name: a file name
-        :param str,None content_type: the MIME type, or ``None`` to accept the default based on file extension of the B2 file name
-        :param dict,None file_info: a file info to store with the file or ``None`` to not store anything
-        """
-        validate_b2_file_name(file_name)
-        return self.api.services.large_file.start_large_file(
-            self.id_, file_name, content_type=content_type, file_info=file_info
-        )
-
     @limit_trace_arguments(skip=('data_bytes',))
     def upload_bytes(
         self,
@@ -809,44 +796,6 @@ class Bucket(metaclass=B2TraceMeta):
                 progress_listener=progress_listener,
                 encryption=destination_encryption,
             )
-
-    # FIXME: this shold be deprecated
-    def copy_file(
-        self,
-        file_id,
-        new_file_name,
-        bytes_range=None,
-        metadata_directive=None,
-        content_type=None,
-        file_info=None,
-        destination_encryption: Optional[EncryptionSetting] = None,
-        source_encryption: Optional[EncryptionSetting] = None,
-    ):
-        """
-        Creates a new file in this bucket by (server-side) copying from an existing file.
-
-        :param str file_id: file ID of existing file
-        :param str new_file_name: file name of the new file
-        :param tuple[int,int],None bytes_range: start and end offsets (**inclusive!**), default is the entire file
-        :param b2sdk.v1.MetadataDirectiveMode,None metadata_directive: default is :py:attr:`b2sdk.v1.MetadataDirectiveMode.COPY`
-        :param str,None content_type: content_type for the new file if metadata_directive is set to :py:attr:`b2sdk.v1.MetadataDirectiveMode.REPLACE`, default will copy the content_type of old file
-        :param dict,None file_info: file_info for the new file if metadata_directive is set to :py:attr:`b2sdk.v1.MetadataDirectiveMode.REPLACE`, default will copy the file_info of old file
-        :param b2sdk.v1.EncryptionSetting destination_encryption: encryption settings for the destination
-                (``None`` if unknown)
-        :param b2sdk.v1.EncryptionSetting source_encryption: encryption settings for the source
-                (``None`` if unknown)
-        """
-        return self.api.session.copy_file(
-            file_id,
-            new_file_name,
-            bytes_range,
-            metadata_directive,
-            content_type,
-            file_info,
-            self.id_,
-            destination_server_side_encryption=destination_encryption,
-            source_server_side_encryption=source_encryption,
-        )
 
     def delete_file_version(self, file_id, file_name):
         """

--- a/b2sdk/v1/__init__.py
+++ b/b2sdk/v1/__init__.py
@@ -12,6 +12,8 @@ from b2sdk._v2 import *  # noqa
 from b2sdk.v1.account_info import (
     AbstractAccountInfo, InMemoryAccountInfo, UrlPoolAccountInfo, SqliteAccountInfo
 )
+from b2sdk.v1.api import B2Api
+from b2sdk.v1.bucket import Bucket, BucketFactory
 from b2sdk.v1.cache import AbstractCache
 from b2sdk.v1.sync import (
     ScanPoliciesManager, DEFAULT_SCAN_MANAGER, zip_folders, Synchronizer, AbstractFolder,

--- a/b2sdk/v1/api.py
+++ b/b2sdk/v1/api.py
@@ -8,12 +8,17 @@
 #
 ######################################################################
 
+from .bucket import Bucket, BucketFactory
 from b2sdk import _v2 as v2
 
 
 # override to use legacy no-request method of creating a bucket from bucket_id and retain `check_bucket_restrictions`
 # public API method
+# and to use v1.Bucket
 class B2Api(v2.B2Api):
+    BUCKET_FACTORY_CLASS = staticmethod(BucketFactory)
+    BUCKET_CLASS = staticmethod(Bucket)
+
     def get_bucket_by_id(self, bucket_id):
         """
         Return a bucket object with a given ID.  Unlike ``get_bucket_by_name``, this method does not need to make any API calls.

--- a/b2sdk/v1/bucket.py
+++ b/b2sdk/v1/bucket.py
@@ -1,0 +1,70 @@
+######################################################################
+#
+# File: b2sdk/v1/bucket.py
+#
+# Copyright 2021 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from typing import Optional
+from b2sdk import _v2 as v2
+from b2sdk.utils import validate_b2_file_name
+
+
+# Overridden to retain the obsolete copy_file and start_large_file methods
+class Bucket(v2.Bucket):
+    def copy_file(
+        self,
+        file_id,
+        new_file_name,
+        bytes_range=None,
+        metadata_directive=None,
+        content_type=None,
+        file_info=None,
+        destination_encryption: Optional[v2.EncryptionSetting] = None,
+        source_encryption: Optional[v2.EncryptionSetting] = None,
+    ):
+        """
+        Creates a new file in this bucket by (server-side) copying from an existing file.
+
+        :param str file_id: file ID of existing file
+        :param str new_file_name: file name of the new file
+        :param tuple[int,int],None bytes_range: start and end offsets (**inclusive!**), default is the entire file
+        :param b2sdk.v1.MetadataDirectiveMode,None metadata_directive: default is :py:attr:`b2sdk.v1.MetadataDirectiveMode.COPY`
+        :param str,None content_type: content_type for the new file if metadata_directive is set to :py:attr:`b2sdk.v1.MetadataDirectiveMode.REPLACE`, default will copy the content_type of old file
+        :param dict,None file_info: file_info for the new file if metadata_directive is set to :py:attr:`b2sdk.v1.MetadataDirectiveMode.REPLACE`, default will copy the file_info of old file
+        :param b2sdk.v1.EncryptionSetting destination_encryption: encryption settings for the destination
+                (``None`` if unknown)
+        :param b2sdk.v1.EncryptionSetting source_encryption: encryption settings for the source
+                (``None`` if unknown)
+        """
+        return self.api.session.copy_file(
+            file_id,
+            new_file_name,
+            bytes_range,
+            metadata_directive,
+            content_type,
+            file_info,
+            self.id_,
+            destination_server_side_encryption=destination_encryption,
+            source_server_side_encryption=source_encryption,
+        )
+
+    def start_large_file(self, file_name, content_type=None, file_info=None):
+        """
+        Start a large file transfer.
+
+        :param str file_name: a file name
+        :param str,None content_type: the MIME type, or ``None`` to accept the default based on file extension of the B2 file name
+        :param dict,None file_info: a file info to store with the file or ``None`` to not store anything
+        """
+        validate_b2_file_name(file_name)
+        return self.api.services.large_file.start_large_file(
+            self.id_, file_name, content_type=content_type, file_info=file_info
+        )
+
+
+class BucketFactory(v2.BucketFactory):
+    BUCKET_CLASS = staticmethod(Bucket)


### PR DESCRIPTION
Resolves  https://github.com/Backblaze/b2-sdk-python/issues/210 and https://github.com/Backblaze/b2-sdk-python/issues/190

replaces https://github.com/reef-technologies/b2-sdk-python/pull/142