### PR TITLE
Application key restriction message reverted to previous form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Cleanup sync errors related to directories
 * Use proper error handling in `ScanPoliciesManager`
+* Application key restriction message reverted to previous form
 
 ### Changed
 * `b2sdk.v1.sync` refactored to reflect `b2sdk.sync` structure

--- a/b2sdk/api.py
+++ b/b2sdk/api.py
@@ -327,10 +327,10 @@ class B2Api(metaclass=B2TraceMeta):
         # allow access to the named bucket.
         if bucket_name is not None and bucket_id is not None:
             raise ValueError('Provide either bucket_name or bucket_id, not both')
-        if bucket_name:
-            self.check_bucket_name_restrictions(bucket_name)
-        else:
+        if bucket_id:
             self.check_bucket_id_restrictions(bucket_id)
+        else:
+            self.check_bucket_name_restrictions(bucket_name)
 
         account_id = self.account_info.get_account_id()
 

--- a/test/unit/v0/test_api.py
+++ b/test/unit/v0/test_api.py
@@ -114,7 +114,9 @@ class TestApi(TestBase):
         bucket2 = self.api.create_bucket('bucket2', 'allPrivate')
         key = self.api.create_key(['listBuckets'], 'key1', bucket_id=bucket1.id_)
         self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
-        with self.assertRaises(RestrictedBucket):
+        with self.assertRaises(
+            RestrictedBucket, 'Application key is restricted to bucket: bucket1'
+        ):
             self.api.list_buckets(bucket_name=bucket2.name)
 
     def test_list_buckets_with_restriction_and_no_name(self):
@@ -123,8 +125,21 @@ class TestApi(TestBase):
         self.api.create_bucket('bucket2', 'allPrivate')
         key = self.api.create_key(['listBuckets'], 'key1', bucket_id=bucket1.id_)
         self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
-        with self.assertRaises(RestrictedBucket):
+        with self.assertRaises(
+            RestrictedBucket, 'Application key is restricted to bucket: bucket1'
+        ):
             self.api.list_buckets()
+
+    def test_list_buckets_with_restriction_and_wrong_id(self):
+        self._authorize_account()
+        bucket1 = self.api.create_bucket('bucket1', 'allPrivate')
+        self.api.create_bucket('bucket2', 'allPrivate')
+        key = self.api.create_key(['listBuckets'], 'key1', bucket_id=bucket1.id_)
+        self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
+        with self.assertRaises(
+            RestrictedBucket, 'Application key is restricted to bucket: %s' % (bucket1.id_,)
+        ):
+            self.api.list_buckets(bucket_id='not the one bound to the key')
 
     def _authorize_account(self):
         self.api.authorize_account('production', self.application_key_id, self.master_key)

--- a/test/unit/v1/test_api.py
+++ b/test/unit/v1/test_api.py
@@ -180,7 +180,9 @@ class TestApi(TestBase):
         bucket2 = self.api.create_bucket('bucket2', 'allPrivate')
         key = self.api.create_key(['listBuckets'], 'key1', bucket_id=bucket1.id_)
         self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
-        with self.assertRaises(RestrictedBucket):
+        with self.assertRaises(
+            RestrictedBucket, 'Application key is restricted to bucket: bucket1'
+        ):
             self.api.list_buckets(bucket_name=bucket2.name)
 
     def test_list_buckets_with_restriction_and_no_name(self):
@@ -189,8 +191,21 @@ class TestApi(TestBase):
         self.api.create_bucket('bucket2', 'allPrivate')
         key = self.api.create_key(['listBuckets'], 'key1', bucket_id=bucket1.id_)
         self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
-        with self.assertRaises(RestrictedBucket):
+        with self.assertRaises(
+            RestrictedBucket, 'Application key is restricted to bucket: bucket1'
+        ):
             self.api.list_buckets()
+
+    def test_list_buckets_with_restriction_and_wrong_id(self):
+        self._authorize_account()
+        bucket1 = self.api.create_bucket('bucket1', 'allPrivate')
+        self.api.create_bucket('bucket2', 'allPrivate')
+        key = self.api.create_key(['listBuckets'], 'key1', bucket_id=bucket1.id_)
+        self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
+        with self.assertRaises(
+            RestrictedBucket, 'Application key is restricted to bucket: %s' % (bucket1.id_,)
+        ):
+            self.api.list_buckets(bucket_id='not the one bound to the key')
 
     def _authorize_account(self):
         self.api.authorize_account('production', self.application_key_id, self.master_key)


### PR DESCRIPTION
replaces https://github.com/reef-technologies/b2-sdk-python/pull/152

Previous changes accidentally changed a specific error message and that cause CLI tests to fail.