### PR TITLE
remove legacy FileVersionInfo.format_ls_entry and FileVersionInfo.format_folder_ls_entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 * Remove `Bucket.copy_file` and `Bucket.start_large_file` 
+* Remove `FileVersionInfo.format_ls_entry` and `FileVersionInfo.format_folder_ls_entry`
 
 ## [1.7.0] - 2021-04-22
 

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -9,7 +9,6 @@
 ######################################################################
 
 from typing import Optional
-import datetime
 
 from .encryption.setting import EncryptionSetting, EncryptionSettingFactory
 
@@ -32,7 +31,6 @@ class FileVersionInfo(object):
     :vartype ~.upload_timestamp: int or None
     :ivar str ~.action: ``"upload"``, ``"hide"`` or ``"delete"``
     """
-    LS_ENTRY_TEMPLATE = '%83s  %6s  %10s  %8s  %9d  %s'  # order is file_id, action, date, time, size, name
 
     __slots__ = [
         'id_', 'file_name', 'size', 'content_type', 'content_sha1', 'content_md5', 'file_info',
@@ -85,26 +83,6 @@ class FileVersionInfo(object):
         if self.server_side_encryption is not None:  # this is for backward compatibility of interface only, b2sdk always sets it
             result['serverSideEncryption'] = self.server_side_encryption.as_dict()
         return result
-
-    def format_ls_entry(self):
-        """ legacy method, to be removed in v2: formats a `ls` entry for b2 command line tool """
-        dt = datetime.datetime.utcfromtimestamp(self.upload_timestamp / 1000)
-        date_str = dt.strftime('%Y-%m-%d')
-        time_str = dt.strftime('%H:%M:%S')
-        size = self.size or 0  # required if self.action == 'hide'
-        return self.LS_ENTRY_TEMPLATE % (
-            self.id_,
-            self.action,
-            date_str,
-            time_str,
-            size,
-            self.file_name,
-        )
-
-    @classmethod
-    def format_folder_ls_entry(cls, name):
-        """ legacy method, to be removed in v2: formats a `ls` "folder" consistently with format_ls_entry() """
-        return cls.LS_ENTRY_TEMPLATE % ('-', '-', '-', '-', 0, name)
 
     def __eq__(self, other):
         sentry = object()

--- a/b2sdk/v1/file_version.py
+++ b/b2sdk/v1/file_version.py
@@ -1,0 +1,36 @@
+######################################################################
+#
+# File: b2sdk/v1/file_version.py
+#
+# Copyright 2021 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+import datetime
+
+from b2sdk import _v2 as v2
+
+
+# override to retain old formatting methods
+class FileVersionInfo(v2.FileVersionInfo):
+    LS_ENTRY_TEMPLATE = '%83s  %6s  %10s  %8s  %9d  %s'  # order is file_id, action, date, time, size, name
+
+    def format_ls_entry(self):
+        dt = datetime.datetime.utcfromtimestamp(self.upload_timestamp / 1000)
+        date_str = dt.strftime('%Y-%m-%d')
+        time_str = dt.strftime('%H:%M:%S')
+        size = self.size or 0  # required if self.action == 'hide'
+        return self.LS_ENTRY_TEMPLATE % (
+            self.id_,
+            self.action,
+            date_str,
+            time_str,
+            size,
+            self.file_name,
+        )
+
+    @classmethod
+    def format_folder_ls_entry(cls, name):
+        return cls.LS_ENTRY_TEMPLATE % ('-', '-', '-', '-', 0, name)


### PR DESCRIPTION
replaces https://github.com/reef-technologies/b2-sdk-python/pull/162