### PR TITLE
Fix crash when Content-Range header is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use proper error handling in `ScanPoliciesManager`
 * Application key restriction message reverted to previous form
 * Added missing apiver wrappers for FileVersionInfo
+* Fix crash when Content-Range header is missing
 
 ### Changed
 * `b2sdk.v1.sync` refactored to reflect `b2sdk.sync` structure

--- a/b2sdk/transfer/inbound/download_manager.py
+++ b/b2sdk/transfer/inbound/download_manager.py
@@ -19,7 +19,6 @@ from b2sdk.exception import (
     ChecksumMismatch,
     InvalidRange,
     TruncatedOutput,
-    UnexpectedCloudBehaviour,
 )
 from b2sdk.raw_api import SRC_LAST_MODIFIED_MILLIS
 from b2sdk.utils import B2TraceMetaAbstract
@@ -93,8 +92,7 @@ class DownloadManager(metaclass=B2TraceMetaAbstract):
         ) as response:
             metadata = FileMetadata.from_response(response)
             if range_ is not None:
-                if 'Content-Range' not in response.headers:
-                    raise UnexpectedCloudBehaviour('Content-Range header was expected')
+                # 2021-05-20: unfortunately for a read of a complete object server does not return the 'Content-Range' header
                 if (range_[1] - range_[0] + 1) != metadata.content_length:
                     raise InvalidRange(metadata.content_length, range_)
 


### PR DESCRIPTION
The server should return it if the range contains the whole file, but apparently it does not do that and that causes crashes which `b2-sdk-python` can just avoid with no consequences.