### PR TITLE
Remove upper bound on the importlib-metadata dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
 * The `importlib-metadata` requirement is less strictly bound now (just >=3.3.0 for python > 3.5).
 
 ## [1.11.0] - 2021-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* The `importlib-metadata` requirement is less strictly bound now (just >=3.3.0 for python > 3.5).
+
 ## [1.11.0] - 2021-06-24
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow>=0.8.0,<1.0.0
 importlib-metadata>=2.1.1,<3.0.0; python_version <= '3.5'
-importlib-metadata>=3.3.0; python_version > '3.5'
+importlib-metadata>=3.3.0; python_version > '3.5' and python_version < '3.8'
 logfury>=0.1.2,<0.2.0
 requests>=2.9.1,<3.0.0
 tqdm>=4.5.0,<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arrow>=0.8.0,<1.0.0
 importlib-metadata>=2.1.1,<3.0.0; python_version <= '3.5'
-importlib-metadata>=3.3.0,<4.0.0; python_version > '3.5' and python_version < '3.8'
+importlib-metadata>=3.3.0; python_version > '3.5'
 logfury>=0.1.2,<0.2.0
 requests>=2.9.1,<3.0.0
 tqdm>=4.5.0,<5.0.0


### PR DESCRIPTION
### Description:

This PR removes the <4.0.0 restriction on the `importlib-metadata` dependency. 

* I briefly [chatted with Maciej](https://b2commandlinetool.slack.com/archives/C0J704CH4/p1624646795041900) regarding the configuration as it is now and the belief is that version 4.0 will not break semantic versioning.
* For testing I will rely on the CI jobs to iterate over the various python flavors and hopefully merge this.
* On the Backblaze backend side we build various tools that depend on `b2-sdk-python` and we have been experiencing flakey behavior resolving build dependencies recently after switching to wheels for builds. This will hopefully simplify the dependency tree significantly and allow for using `importlib-metadata` 4.5.

### Testing:

* Created virtualenv off of the changed `requirements.txt`. Ran all local unit tests and linters. Resolving checks as I go along. 