### PR TITLE
Allow for arrow >= 1.0.2 on Python 3.6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Relax constraint on arrow to allow for versions >= 1.0.2
+
 ## [1.13.0] - 2021-10-24
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-arrow>=0.8.0,<1.0.0
+arrow>=0.8.0,<1.0.0; python_version <= '3.5'
+arrow>=1.0.2,<2.0.0; python_version >= '3.6'
 importlib-metadata>=2.1.1,<3.0.0; python_version <= '3.5'
 importlib-metadata>=3.3.0; python_version > '3.5' and python_version < '3.8'
 logfury>=1.0.1,<2.0.0


### PR DESCRIPTION
Closes https://github.com/Backblaze/b2-sdk-python/issues/201