### PR TITLE
Fix filename in get_file_info_by_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix downloading files with unverified checksum
+* Fix decoding in filename and file info of `DownloadVersion`
 
 ### Changed
 * Don't run coverage in pypy in CI

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -236,9 +236,11 @@ class Bucket(metaclass=B2TraceMeta):
         :param str file_name: the name of the file who's info will be retrieved.
         """
         try:
-            return self.api.download_version_factory.from_response_headers(
+            download_version = self.api.download_version_factory.from_response_headers(
                 self.api.session.get_file_info_by_name(self.name, file_name)
             )
+            download_version._set_filename(file_name)
+            return download_version
         except FileOrBucketNotFound:
             raise FileNotPresent(bucket_name=self.name, file_id_or_name=file_name)
 

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -236,11 +236,9 @@ class Bucket(metaclass=B2TraceMeta):
         :param str file_name: the name of the file who's info will be retrieved.
         """
         try:
-            download_version = self.api.download_version_factory.from_response_headers(
+            return self.api.download_version_factory.from_response_headers(
                 self.api.session.get_file_info_by_name(self.name, file_name)
             )
-            download_version._set_filename(file_name)
-            return download_version
         except FileOrBucketNotFound:
             raise FileNotPresent(bucket_name=self.name, file_id_or_name=file_name)
 

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -15,6 +15,7 @@ from .http_constants import FILE_INFO_HEADER_PREFIX_LOWER, SRC_LAST_MODIFIED_MIL
 from .file_lock import FileRetentionSetting, LegalHold, NO_RETENTION_FILE_SETTING
 from .progress import AbstractProgressListener
 from .utils.range_ import Range
+from .utils import b2_url_decode
 
 if TYPE_CHECKING:
     from .api import B2Api
@@ -345,9 +346,6 @@ class DownloadVersion(BaseFileVersion):
             }
         )
         return args
-    
-    def _set_filename(self, filename):
-        self.file_name = filename
 
 
 class FileVersionFactory(object):
@@ -469,7 +467,7 @@ class DownloadVersionFactory(object):
         return DownloadVersion(
             api=self.api,
             id_=headers['x-bz-file-id'],
-            file_name=headers['x-bz-file-name'],
+            file_name=b2_url_decode(headers['x-bz-file-name']),
             size=size,
             content_type=headers['content-type'],
             content_sha1=headers['x-bz-content-sha1'],

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -345,6 +345,9 @@ class DownloadVersion(BaseFileVersion):
             }
         )
         return args
+    
+    def _set_filename(self, filename):
+        self.file_name = filename
 
 
 class FileVersionFactory(object):

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -452,7 +452,7 @@ class DownloadVersionFactory(object):
         for header_name, header_value in headers.items():
             if header_name[:prefix_len].lower() == FILE_INFO_HEADER_PREFIX_LOWER:
                 file_info_key = header_name[prefix_len:]
-                file_info[file_info_key] = header_value
+                file_info[file_info_key] = b2_url_decode(header_value)
         return file_info
 
     def from_response_headers(self, headers):

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -225,7 +225,7 @@ class FileSimulator(object):
                 'x-bz-content-sha1': self.content_sha1,
                 'x-bz-upload-timestamp': self.upload_timestamp,
                 'x-bz-file-id': self.file_id,
-                'x-bz-file-name': self.name,
+                'x-bz-file-name': b2_url_encode(self.name),
             }
         )
         for key, value in self.file_info.items():

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -233,7 +233,7 @@ class FileSimulator(object):
             if key_lower in self.SPECIAL_FILE_INFOS:
                 headers[self.SPECIAL_FILE_INFOS[key_lower]] = value
             else:
-                headers[FILE_INFO_HEADER_PREFIX + key] = value
+                headers[FILE_INFO_HEADER_PREFIX + key] = b2_url_encode(value)
 
         if account_auth_token_or_none is not None and self.bucket.is_file_lock_enabled:
             not_permitted = []

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -1876,8 +1876,18 @@ class DecodeTests(DecodeTestsBase, TestCaseWithBucket):
 
     def test_file_info_1(self):
         download_version = self.bucket.get_file_info_by_name('test.txt?foo=bar')
+        assert download_version.file_name == 'test.txt?foo=bar'
         assert download_version.file_info['custom_info'] == 'aaa?bbb'
 
     def test_file_info_2(self):
         download_version = self.bucket.get_file_info_by_name('test.txt%3Ffoo=bar')
+        assert download_version.file_name == 'test.txt%3Ffoo=bar'
         assert download_version.file_info['custom_info'] == 'aaa%3Fbbb'
+
+    def test_file_info_3(self):
+        download_version = self.bucket.get_file_info_by_name('test.txt%3Ffoo%3Dbar')
+        assert download_version.file_name == 'test.txt%3Ffoo%3Dbar'
+
+    def test_file_info_4(self):
+        download_version = self.bucket.get_file_info_by_name('test.txt%253Ffoo%253Dbar')
+        assert download_version.file_name == 'test.txt%253Ffoo%253Dbar'

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -1810,3 +1810,74 @@ class TestTruncatedDownloadParallel(DownloadTests, TestCaseWithTruncatedDownload
                 min_part_size=2,
             )
         ]
+
+
+class DecodeTestsBase(object):
+    def setUp(self):
+        super(DecodeTestsBase, self).setUp()
+        self.bucket.upload_bytes(
+            'Test File 1'.encode(), 'test.txt?foo=bar', file_infos={'custom_info': 'aaa?bbb'}
+        )
+        self.bucket.upload_bytes(
+            'Test File 2'.encode(), 'test.txt%3Ffoo=bar', file_infos={'custom_info': 'aaa%3Fbbb'}
+        )
+        self.bucket.upload_bytes('Test File 3'.encode(), 'test.txt%3Ffoo%3Dbar')
+        self.bucket.upload_bytes('Test File 4'.encode(), 'test.txt%253Ffoo%253Dbar')
+        self.bytes_io = io.BytesIO()
+        if apiver_deps.V <= 1:
+            self.download_dest = DownloadDestBytes()
+        else:
+            self.download_dest = None
+        self.progress_listener = StubProgressListener()
+
+    def _verify(self, expected_result, check_progress_listener=True):
+        self._assert_downloaded_data(expected_result)
+        if check_progress_listener:
+            valid, reason = self.progress_listener.is_valid_reason(
+                check_closed=False,
+                check_progress=False,
+                check_monotonic_progress=True,
+            )
+            assert valid, reason
+
+    def _assert_downloaded_data(self, expected_result):
+        if apiver_deps.V <= 1:
+            assert self.download_dest.get_bytes_written() == expected_result.encode()
+        else:
+            assert self.bytes_io.getvalue() == expected_result.encode()
+
+    def download_file_by_name(self, file_name, download_dest=None, **kwargs):
+        if apiver_deps.V <= 1:
+            self.bucket.download_file_by_name(
+                file_name, download_dest or self.download_dest, **kwargs
+            )
+        else:
+            self.bucket.download_file_by_name(file_name, **kwargs).save(self.bytes_io)
+
+
+class DecodeTests(DecodeTestsBase, TestCaseWithBucket):
+    def test_file_content_1(self):
+        self.download_file_by_name('test.txt?foo=bar', progress_listener=self.progress_listener)
+        self._verify("Test File 1")
+
+    def test_file_content_2(self):
+        self.download_file_by_name('test.txt%3Ffoo=bar', progress_listener=self.progress_listener)
+        self._verify("Test File 2")
+
+    def test_file_content_3(self):
+        self.download_file_by_name('test.txt%3Ffoo%3Dbar', progress_listener=self.progress_listener)
+        self._verify("Test File 3")
+
+    def test_file_content_4(self):
+        self.download_file_by_name(
+            'test.txt%253Ffoo%253Dbar', progress_listener=self.progress_listener
+        )
+        self._verify("Test File 4")
+
+    def test_file_info_1(self):
+        download_version = self.bucket.get_file_info_by_name('test.txt?foo=bar')
+        assert download_version.file_info['custom_info'] == 'aaa?bbb'
+
+    def test_file_info_2(self):
+        download_version = self.bucket.get_file_info_by_name('test.txt%3Ffoo=bar')
+        assert download_version.file_info['custom_info'] == 'aaa%3Fbbb'


### PR DESCRIPTION
During using b2 object storage API, I found that file names such as `test.txt?a=1` could be uploaded. However, the following code would throw a `FileNotPresent` error as the file name returned in the HTTP header is its encoded `test.txt%3Fa=1` which could be another file.

```python
file_info = bucket.get_file_info_by_name('test.txt?a=1')
print(file_info)
bucket.delete_file_version(file_info.id_, file_info.file_name)
```

In this PR, I manually set the file name field in `DownloadVersion` to the file name in the parameter to fix this problem.

Signed-off-by: KernelErr <me@lirui.tech>