### PR TITLE
Add stats for parallel downloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Logging performance summary of parallel download writer threads
+* Logging performance summary of parallel download threads
 
 ### Fixed
 * Fix: replace `ReplicationScanResult.source_has_sse_c_enabled` with `source_encryption_mode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ### Added
 * Logging performance summary of parallel download writer threads
 
-## [Unreleased]
-
 ### Fixed
 * Fix: replace `ReplicationScanResult.source_has_sse_c_enabled` with `source_encryption_mode`
+* Fix calling `CopySizeTooBig` exception
 
 ### Infrastructure
 * Fix nox's deprecated `session.install()` calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+* Logging performance summary of parallel download writer threads
+
 ## [Unreleased]
 
 ### Fixed

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -566,7 +566,7 @@ def interpret_b2_error(
         matcher = COPY_SOURCE_TOO_BIG_ERROR_MESSAGE_RE.match(message)
         if matcher is not None:
             size = int(matcher.group('size'))
-            return CopySourceTooBig(size)
+            return CopySourceTooBig(message, code, size)
 
         return BadRequest(message, code)
     elif status == 400:

--- a/b2sdk/stream/progress.py
+++ b/b2sdk/stream/progress.py
@@ -36,6 +36,9 @@ class AbstractStreamWithProgress(StreamWrapper):
         self.bytes_completed += delta
         self.progress_listener.bytes_completed(self.bytes_completed + self.offset)
 
+    def __str__(self):
+        return str(self.stream)
+
 
 class ReadingStreamWithProgress(AbstractStreamWithProgress):
     """

--- a/b2sdk/transfer/inbound/downloaded_file.py
+++ b/b2sdk/transfer/inbound/downloaded_file.py
@@ -79,6 +79,9 @@ class MtimeUpdatedFile(io.IOBase):
         self.file.close()
         set_file_mtime(self.path_, self.mod_time_to_set)
 
+    def __str__(self):
+        return str(self.path_)
+
 
 class DownloadedFile:
     """

--- a/b2sdk/transfer/inbound/downloader/parallel.py
+++ b/b2sdk/transfer/inbound/downloader/parallel.py
@@ -205,20 +205,20 @@ class WriterThread(threading.Thread):
         self.file = file
         self.queue = queue.Queue(max_queue_depth)
         self.total = 0
-        self.stats_collector = StatsCollector(str(self.file))
+        self.stats_collector = StatsCollector(str(self.file), 'seek')
         super(WriterThread, self).__init__()
     def run(self):
         file = self.file
         queue_get = self.queue.get
-        stats_collector_get_append = self.stats_collector.get.append
-        stats_collector_seek_append = self.stats_collector.seek.append
+        stats_collector_read_append = self.stats_collector.read.append
+        stats_collector_other_append = self.stats_collector.other.append
         stats_collector_write_append = self.stats_collector.write.append
         start = perf_counter_ns()
         while 1:
 
-            before_get = perf_counter_ns()
+            before_read = perf_counter_ns()
             shutdown, offset, data = queue_get()
-            stats_collector_get_append(perf_counter_ns()-before_get)
+            stats_collector_read_append(perf_counter_ns()-before_read)
 
             if shutdown:
                 break
@@ -227,7 +227,7 @@ class WriterThread(threading.Thread):
             after_seek = perf_counter_ns()
             file.write(data)
             after_write = perf_counter_ns()
-            stats_collector_seek_append(after_seek-before_seek)
+            stats_collector_other_append(after_seek-before_seek)
             stats_collector_write_append(after_write-after_seek)
             self.total += len(data)
         self.stats_collector.total = perf_counter_ns()-start

--- a/b2sdk/transfer/inbound/downloader/parallel.py
+++ b/b2sdk/transfer/inbound/downloader/parallel.py
@@ -318,7 +318,6 @@ def download_first_part(
         bytes_read += len(to_write)
         if stop:
             break
-        before_read = perf_counter_ns()
 
     # since we got everything we need from original response, close the socket and free the buffer
     # to avoid a timeout exception during hashing and other trouble

--- a/b2sdk/transfer/inbound/downloader/stats_collector.py
+++ b/b2sdk/transfer/inbound/downloader/stats_collector.py
@@ -1,0 +1,34 @@
+######################################################################
+#
+# File: b2sdk/transfer/inbound/downloader/stats_collector.py
+#
+# Copyright 2020 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+import logging
+from dataclasses import dataclass, field
+from typing import List  # 3.7 doesn't understand `list` vs `List`
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StatsCollector:
+    name: str
+    total: Optional[int] = None
+    seek: List[int] = field(default_factory=list)
+    write: List[int] = field(default_factory=list)
+    get: List[int] = field(default_factory=list)
+    def report(self):
+        logger.info('download stats | %s | TTFB: %.3f ms', self.name, self.get[0] / 1000000)
+        logger.info('download stats | %s | get() without TTFB: %.3f ms',self.name,  sum(self.get[1:]) / 1000000)
+        logger.info('download stats | %s | seek() total: %.3f ms', self.name, sum(self.seek) / 1000000)
+        logger.info('download stats | %s | write() total: %.3f ms', self.name, sum(self.write) / 1000000)
+        if self.total is not None:
+            overhead = self.total - sum(self.write) - sum(self.seek) - sum(self.get)
+            logger.info('download stats | %s | overhead: %.3f ms', self.name, overhead / 1000000)

--- a/b2sdk/transfer/inbound/downloader/stats_collector.py
+++ b/b2sdk/transfer/inbound/downloader/stats_collector.py
@@ -20,15 +20,19 @@ logger = logging.getLogger(__name__)
 @dataclass
 class StatsCollector:
     name: str
+    other_name: str  #: other statistic, typically "seek" or "hash"
     total: Optional[int] = None
-    seek: List[int] = field(default_factory=list)
+    other: List[int] = field(default_factory=list)
     write: List[int] = field(default_factory=list)
-    get: List[int] = field(default_factory=list)
+    read: List[int] = field(default_factory=list)
     def report(self):
-        logger.info('download stats | %s | TTFB: %.3f ms', self.name, self.get[0] / 1000000)
-        logger.info('download stats | %s | get() without TTFB: %.3f ms',self.name,  sum(self.get[1:]) / 1000000)
-        logger.info('download stats | %s | seek() total: %.3f ms', self.name, sum(self.seek) / 1000000)
-        logger.info('download stats | %s | write() total: %.3f ms', self.name, sum(self.write) / 1000000)
+        if self.read:
+            logger.info('download stats | %s | TTFB: %.3f ms', self.name, self.read[0] / 1000000)
+            logger.info('download stats | %s | read() without TTFB: %.3f ms',self.name,  sum(self.read[1:]) / 1000000)
+        if self.other:
+            logger.info('download stats | %s | %s total: %.3f ms', self.name, self.other_name, sum(self.other) / 1000000)
+        if self.write:
+            logger.info('download stats | %s | write() total: %.3f ms', self.name, sum(self.write) / 1000000)
         if self.total is not None:
-            overhead = self.total - sum(self.write) - sum(self.seek) - sum(self.get)
+            overhead = self.total - sum(self.write) - sum(self.other) - sum(self.read)
             logger.info('download stats | %s | overhead: %.3f ms', self.name, overhead / 1000000)

--- a/b2sdk/transfer/inbound/downloader/stats_collector.py
+++ b/b2sdk/transfer/inbound/downloader/stats_collector.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from typing import List  # 3.7 doesn't understand `list` vs `List`
 from typing import Optional
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -25,14 +24,24 @@ class StatsCollector:
     other: List[int] = field(default_factory=list)
     write: List[int] = field(default_factory=list)
     read: List[int] = field(default_factory=list)
+
     def report(self):
         if self.read:
             logger.info('download stats | %s | TTFB: %.3f ms', self.name, self.read[0] / 1000000)
-            logger.info('download stats | %s | read() without TTFB: %.3f ms',self.name,  sum(self.read[1:]) / 1000000)
+            logger.info(
+                'download stats | %s | read() without TTFB: %.3f ms', self.name,
+                sum(self.read[1:]) / 1000000
+            )
         if self.other:
-            logger.info('download stats | %s | %s total: %.3f ms', self.name, self.other_name, sum(self.other) / 1000000)
+            logger.info(
+                'download stats | %s | %s total: %.3f ms', self.name, self.other_name,
+                sum(self.other) / 1000000
+            )
         if self.write:
-            logger.info('download stats | %s | write() total: %.3f ms', self.name, sum(self.write) / 1000000)
+            logger.info(
+                'download stats | %s | write() total: %.3f ms', self.name,
+                sum(self.write) / 1000000
+            )
         if self.total is not None:
             overhead = self.total - sum(self.write) - sum(self.other) - sum(self.read)
             logger.info('download stats | %s | overhead: %.3f ms', self.name, overhead / 1000000)

--- a/b2sdk/transfer/inbound/downloader/stats_collector.py
+++ b/b2sdk/transfer/inbound/downloader/stats_collector.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class StatsCollector:
-    name: str
+    name: str  #: file name or object url
+    detail: str  #: description of the thread, ex. "10000000:20000000" or "writer"
     other_name: str  #: other statistic, typically "seek" or "hash"
     total: Optional[int] = None
     other: List[int] = field(default_factory=list)
@@ -27,21 +28,24 @@ class StatsCollector:
 
     def report(self):
         if self.read:
-            logger.info('download stats | %s | TTFB: %.3f ms', self.name, self.read[0] / 1000000)
+            logger.info('download stats | %s | TTFB: %.3f ms', self, self.read[0] / 1000000)
             logger.info(
-                'download stats | %s | read() without TTFB: %.3f ms', self.name,
+                'download stats | %s | read() without TTFB: %.3f ms', self,
                 sum(self.read[1:]) / 1000000
             )
         if self.other:
             logger.info(
-                'download stats | %s | %s total: %.3f ms', self.name, self.other_name,
+                'download stats | %s | %s total: %.3f ms', self, self.other_name,
                 sum(self.other) / 1000000
             )
         if self.write:
             logger.info(
-                'download stats | %s | write() total: %.3f ms', self.name,
+                'download stats | %s | write() total: %.3f ms', self,
                 sum(self.write) / 1000000
             )
         if self.total is not None:
             overhead = self.total - sum(self.write) - sum(self.other) - sum(self.read)
-            logger.info('download stats | %s | overhead: %.3f ms', self.name, overhead / 1000000)
+            logger.info('download stats | %s | overhead: %.3f ms', self, overhead / 1000000)
+
+    def __str__(self):
+        return f'{self.name}[{self.detail}]'


### PR DESCRIPTION
example output
```
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:31 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[5000495:10000990] | TTFB: 0.045 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:32 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[5000495:10000990] | read() without TTFB: 1257.107 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:42 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[5000495:10000990] | write() total: 7.428 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:48 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[5000495:10000990] | overhead: 418.532 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:31 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[0:5000495] | TTFB: 0.035 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:32 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[0:5000495] | read() without TTFB: 2165.175 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:37 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[0:5000495] | hash total: 14.855 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:42 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[0:5000495] | write() total: 10.200 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:48 download stats | https://f001.backblazeb2.com/file/sdktstbkDn4ZgbFCjEC9M1dxFyj8z23IUTu9fvsiT04mV2eovF/small_file[0:5000495] | overhead: 420.607 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:31 download stats | /tmp/tmppnz7p4lz/target_small_file[writer] | TTFB: 420.450 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:32 download stats | /tmp/tmppnz7p4lz/target_small_file[writer] | read() without TTFB: 2154.709 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:37 download stats | /tmp/tmppnz7p4lz/target_small_file[writer] | seek total: 0.116 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:42 download stats | /tmp/tmppnz7p4lz/target_small_file[writer] | write() total: 34.826 ms
INFO     b2sdk.transfer.inbound.downloader.stats_collector:stats_collector.py:48 download stats | /tmp/tmppnz7p4lz/target_small_file[writer] | overhead: 1.727 ms
INFO     b2sdk.transfer.inbound.downloader.parallel:parallel.py:126 download stats | /tmp/tmppnz7p4lz/target_small_file | finish_hash total: 5.730 ms
```
The test was ran on an extremely flakey internet connection which often suffers from >1200 ping and a massive packet loss, so don't look at the actual values but more on the format of the data here.