### PR TITLE
Add `large_file_sha1` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Add `large_file_sha1` support
+
 ## [1.18.0] - 2022-09-20
 
 ### Added

--- a/b2sdk/_v3/__init__.py
+++ b/b2sdk/_v3/__init__.py
@@ -235,5 +235,6 @@ from b2sdk.cache import AuthInfoCache
 from b2sdk.cache import DummyCache
 from b2sdk.cache import InMemoryCache
 from b2sdk.http_constants import SRC_LAST_MODIFIED_MILLIS
+from b2sdk.http_constants import LARGE_FILE_SHA1
 from b2sdk.session import B2Session
 from b2sdk.utils.thread_pool import ThreadPoolMixin

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -575,6 +575,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Creates a new file in this bucket using an iterable (list, tuple etc) of remote or local sources.
@@ -601,6 +602,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self._create_file(
             self.api.services.emerger.emerge,
@@ -616,6 +618,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=None,
         )
 
     def create_file_stream(
@@ -632,6 +635,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Creates a new file in this bucket using a stream of multiple remote or local sources.
@@ -660,6 +664,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self._create_file(
             self.api.services.emerger.emerge_stream,
@@ -675,6 +680,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=large_file_sha1,
         )
 
     def _create_file(
@@ -692,6 +698,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         validate_b2_file_name(file_name)
         progress_listener = progress_listener or DoNothingProgressListener()
@@ -710,6 +717,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=large_file_sha1,
         )
 
     def concatenate(
@@ -726,6 +734,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Creates a new file in this bucket by concatenating multiple remote or local sources.
@@ -749,9 +758,10 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self.create_file(
-            WriteIntent.wrap_sources_iterator(outbound_sources),
+            list(WriteIntent.wrap_sources_iterator(outbound_sources)),
             file_name,
             content_type=content_type,
             file_info=file_info,
@@ -763,6 +773,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=large_file_sha1,
         )
 
     def concatenate_stream(
@@ -777,6 +788,7 @@ class Bucket(metaclass=B2TraceMeta):
         encryption: Optional[EncryptionSetting] = None,
         file_retention: Optional[FileRetentionSetting] = None,
         legal_hold: Optional[LegalHold] = None,
+        large_file_sha1: Optional[str] = None,
     ):
         """
         Creates a new file in this bucket by concatenating stream of multiple remote or local sources.
@@ -799,6 +811,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param b2sdk.v2.EncryptionSetting encryption: encryption setting (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
         :param bool legal_hold: legal hold setting
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self.create_file_stream(
             WriteIntent.wrap_sources_iterator(outbound_sources_iterator),
@@ -811,6 +824,7 @@ class Bucket(metaclass=B2TraceMeta):
             encryption=encryption,
             file_retention=file_retention,
             legal_hold=legal_hold,
+            large_file_sha1=large_file_sha1,
         )
 
     def get_download_url(self, filename):

--- a/b2sdk/http_constants.py
+++ b/b2sdk/http_constants.py
@@ -16,6 +16,7 @@ FILE_INFO_HEADER_PREFIX_LOWER = FILE_INFO_HEADER_PREFIX.lower()
 
 # Standard names for file info entries
 SRC_LAST_MODIFIED_MILLIS = 'src_last_modified_millis'
+LARGE_FILE_SHA1 = 'large_file_sha1'
 
 # Special X-Bz-Content-Sha1 value to verify checksum at the end
 HEX_DIGITS_AT_END = 'hex_digits_at_end'

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -669,7 +669,7 @@ class BucketSimulator:
         return self.file_id_to_file[file_id].as_upload_result(account_auth_token)
 
     def get_file_info_by_name(self, account_auth_token, file_name):
-        for ((name, id), file) in self.file_name_and_id_to_file.items():
+        for ((name, id), file) in sorted(self.file_name_and_id_to_file.items()):
             if file_name == name:
                 return file.as_download_headers(account_auth_token_or_none=account_auth_token)
         raise FileNotPresent(file_id_or_name=file_name, bucket_name=self.bucket_name)

--- a/b2sdk/transfer/emerge/emerger.py
+++ b/b2sdk/transfer/emerge/emerger.py
@@ -10,12 +10,14 @@
 
 import logging
 from typing import Optional
+from collections.abc import Iterator
 
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.file_lock import FileRetentionSetting, LegalHold
-from b2sdk.utils import B2TraceMetaAbstract
+from b2sdk.http_constants import LARGE_FILE_SHA1
 from b2sdk.transfer.emerge.executor import EmergeExecutor
 from b2sdk.transfer.emerge.planner.planner import EmergePlanner
+from b2sdk.utils import B2TraceMetaAbstract, iterator_peek
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +42,24 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         self.services = services
         self.emerge_executor = EmergeExecutor(services)
 
+    @staticmethod
+    def _update_file_info_with_large_file_sha1(
+        file_info, write_intents, emerge_plan, large_file_sha1
+    ):
+        if not emerge_plan.is_large_file():
+            # Emerge plan doesn't construct a large file, no point setting the large_file_sha1
+            return file_info
+
+        if not large_file_sha1 and len(write_intents) == 1:
+            # large_file_sha1 was not given explicitly, but there's just one write intent, perhaps it has a hash
+            large_file_sha1 = write_intents[0].get_large_file_sha1()
+
+        if large_file_sha1:
+            file_info = file_info or {}
+            file_info[LARGE_FILE_SHA1] = large_file_sha1
+
+        return file_info
+
     def emerge(
         self,
         bucket_id,
@@ -55,6 +75,7 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Create a new file (object in the cloud, really) from an iterable (list, tuple etc) of write intents.
@@ -69,6 +90,7 @@ class Emerger(metaclass=B2TraceMetaAbstract):
 
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         # WARNING: time spent trying to extract common parts of emerge() and emerge_stream()
         # into a separate method: 20min. You can try it too, but please increment the timer honestly.
@@ -79,6 +101,11 @@ class Emerger(metaclass=B2TraceMetaAbstract):
             max_part_size=max_part_size,
         )
         emerge_plan = planner.get_emerge_plan(write_intents)  # <--
+
+        file_info = self._update_file_info_with_large_file_sha1(
+            file_info, write_intents, emerge_plan, large_file_sha1
+        )
+
         return self.emerge_executor.execute_emerge_plan(
             emerge_plan,
             bucket_id,
@@ -108,6 +135,7 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Create a new file (object in the cloud, really) from a stream of write intents.
@@ -130,14 +158,26 @@ class Emerger(metaclass=B2TraceMetaAbstract):
 
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
-
+        :param str,None large_file_sha1: result file SHA1 hash or ``None`` if not known
         """
         planner = self.get_emerge_planner(
             min_part_size=min_part_size,
             recommended_upload_part_size=recommended_upload_part_size,
             max_part_size=max_part_size,
         )
+
+        # ensure that write_intent_iterator is an iterator (and not just iterable, like a list)
+        if not isinstance(write_intent_iterator, Iterator):
+            write_intent_iterator = iter(write_intent_iterator)
+
+        first_write_intents, write_intent_iterator = iterator_peek(write_intent_iterator, 2)
+
         emerge_plan = planner.get_streaming_emerge_plan(write_intent_iterator)  # <--
+
+        file_info = self._update_file_info_with_large_file_sha1(
+            file_info, first_write_intents, emerge_plan, large_file_sha1
+        )
+
         return self.emerge_executor.execute_emerge_plan(
             emerge_plan,
             bucket_id,

--- a/b2sdk/transfer/emerge/planner/planner.py
+++ b/b2sdk/transfer/emerge/planner/planner.py
@@ -14,7 +14,6 @@ import json
 
 from abc import ABCMeta, abstractmethod
 from collections import deque
-from itertools import chain
 
 from b2sdk.transfer.emerge.planner.part_definition import (
     CopyEmergePartDefinition,
@@ -25,6 +24,7 @@ from b2sdk.transfer.emerge.planner.upload_subpart import (
     LocalSourceUploadSubpart,
     RemoteSourceUploadSubpart,
 )
+from b2sdk.utils import iterator_peek
 
 MEGABYTE = 1000 * 1000
 GIGABYTE = 1000 * MEGABYTE
@@ -340,10 +340,10 @@ class EmergePlanner:
         return left_buff, UploadBuffer(left_buff.end_offset)
 
     def _select_intent_fragments(self, write_intent_iterator):
-        """ Select overapping write intent fragments to use.
+        """ Select overlapping write intent fragments to use.
 
         To solve overlapping intents selection, intents can be split to smaller fragments.
-        Those fragments are yieled as soon as decision can be made to use them,
+        Those fragments are yielded as soon as decision can be made to use them,
         so there is possibility that one intent is yielded in multiple fragments. Those
         would be merged again by higher level iterator that produces emerge parts, but
         in principle this merging can happen here. Not merging it is a code design decision
@@ -627,8 +627,10 @@ class EmergePlan(BaseEmergePlan):
 
 class StreamingEmergePlan(BaseEmergePlan):
     def __init__(self, emerge_parts_iterator):
-        emerge_parts, self._is_large_file = self._peek_for_large_file(emerge_parts_iterator)
-        super(StreamingEmergePlan, self).__init__(emerge_parts)
+        emerge_parts_iterator, self._is_large_file = self._peek_for_large_file(
+            emerge_parts_iterator
+        )
+        super(StreamingEmergePlan, self).__init__(emerge_parts_iterator)
 
     def is_large_file(self):
         return self._is_large_file
@@ -640,15 +642,12 @@ class StreamingEmergePlan(BaseEmergePlan):
         return None
 
     def _peek_for_large_file(self, emerge_parts_iterator):
-        first_part = next(emerge_parts_iterator, None)
-        if first_part is None:
+        peeked, emerge_parts_iterator = iterator_peek(emerge_parts_iterator, 2)
+
+        if not peeked:
             raise ValueError('Empty emerge parts iterator')
 
-        second_part = next(emerge_parts_iterator, None)
-        if second_part is None:
-            return iter([first_part]), False
-        else:
-            return chain([first_part, second_part], emerge_parts_iterator), True
+        return emerge_parts_iterator, len(peeked) > 1
 
 
 class EmergePart:

--- a/b2sdk/transfer/emerge/write_intent.py
+++ b/b2sdk/transfer/emerge/write_intent.py
@@ -63,6 +63,19 @@ class WriteIntent:
         """
         return self.outbound_source.is_upload()
 
+    def get_large_file_sha1(self):
+        """
+        Return a 40-character string containing the hex SHA1 checksum, which can be used as the `large_file_sha1` entry.
+
+        This method is only used if a large file is constructed from only a single source.  If that source's hash is known,
+        the result file's SHA1 checksum will be the same and can be copied.
+
+        If the source's sha1 is unknown and can't be calculated, `None` is returned.
+
+        :rtype str:
+        """
+        return self.outbound_source.get_large_file_sha1()
+
     @classmethod
     def wrap_sources_iterator(cls, outbound_sources_iterator):
         """ Helper that wraps outbound sources iterator with write intents.

--- a/b2sdk/transfer/outbound/copy_source.py
+++ b/b2sdk/transfer/outbound/copy_source.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.transfer.outbound.outbound_source import OutboundTransferSource
+from b2sdk.http_constants import LARGE_FILE_SHA1
 
 
 class CopySource(OutboundTransferSource):
@@ -80,3 +81,9 @@ class CopySource(OutboundTransferSource):
             source_file_info=self.source_file_info,
             source_content_type=self.source_content_type
         )
+
+    def get_large_file_sha1(self):
+        if self.offset or self.length:
+            # this is a copy of only a range of the source, can't copy the SHA1
+            return None
+        return self.source_file_info.get(LARGE_FILE_SHA1)

--- a/b2sdk/transfer/outbound/outbound_source.py
+++ b/b2sdk/transfer/outbound/outbound_source.py
@@ -32,6 +32,19 @@ class OutboundTransferSource(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def get_large_file_sha1(self):
+        """
+        Return a 40-character string containing the hex SHA1 checksum, which can be used as the `large_file_sha1` entry.
+
+        This method is only used if a large file is constructed from only a single source.  If that source's hash is known,
+        the result file's SHA1 checksum will be the same and can be copied.
+
+        If the source's sha1 is unknown and can't be calculated, `None` is returned. 
+ 
+        :rtype str:
+        """
+
+    @abstractmethod
     def is_upload(self):
         """ Return if outbound source is an upload source.
         :rtype bool:

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -39,6 +39,9 @@ class AbstractUploadSource(OutboundTransferSource):
         :return:
         """
 
+    def get_large_file_sha1(self):
+        return self.get_content_sha1()
+
     def is_upload(self):
         return True
 

--- a/b2sdk/utils/__init__.py
+++ b/b2sdk/utils/__init__.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import concurrent.futures as futures
 from decimal import Decimal
+from itertools import chain
 from urllib.parse import quote, unquote_plus
 
 from logfury.v1 import DefaultTraceAbstractMeta, DefaultTraceMeta, limit_trace_arguments, disable_trace, trace_call
@@ -431,6 +432,24 @@ def current_time_millis():
     File times are in integer milliseconds, to avoid roundoff errors.
     """
     return int(round(time.time() * 1000))
+
+
+def iterator_peek(iterator, count):
+    """
+    Get the `count` first elements yielded by `iterator`.
+
+    The function will read `count` elements from `iterator` or less if the end is reached first.  Returns a tuple
+    consisting of a list of retrieved elements and an iterator equivalent to the input iterator.
+    """
+
+    ret = []
+    for _ in range(count):
+        try:
+            ret.append(next(iterator))
+        except StopIteration:
+            break
+
+    return ret, chain(ret, iterator)
 
 
 assert disable_trace

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -321,7 +321,7 @@ To support automatic continuation, some advanced methods create a plan before st
 If that is not available, ``large_file_id`` can be extracted via callback during the operation start. It can then be passed into the subsequent call to continue the same task, though the responsibility for passing the exact same input is then on the user of the function. Please see :ref:`advanced method support table <advanced_methods_support_table>` to see where automatic continuation is supported. ``large_file_id`` can also be passed if automatic continuation is available in order to avoid issues where multiple matching upload sessions are matching the transfer.
 
 
-Continuation of create/concantenate
+Continuation of create/concatenate
 ===================================
 
 :meth:`b2sdk.v2.Bucket.create_file` supports automatic continuation or manual continuation. :meth:`b2sdk.v2.Bucket.create_file_stream` supports only manual continuation for local-only inputs. The situation looks the same for :meth:`b2sdk.v2.Bucket.concatenate` and :meth:`b2sdk.v2.Bucket.concatenate_stream` (streamed version supports only manual continuation of local sources). Also :meth:`b2sdk.v2.Bucket.upload` and :meth:`b2sdk.v2.Bucket.copy` support both automatic and manual continuation.
@@ -376,3 +376,14 @@ No continuation
 
 
 Note, that this only forces start of a new large file - it is still possible to continue the process with either auto or manual modes.
+
+
+****************************
+SHA-1 hashes for large files
+****************************
+
+Depending the number and size of sources and the size of the result file, the SDK may decide to use the large file API to create a file on the server.  In such cases the file's SHA-1 won't be stored on the server and will not be returned in the ``X-Bz-Content-Sha1`` header.  The SHA-1 can optionally still be stored with the file in the ``large_file_sha1`` entry in the ``file_info``.
+
+In basic scenarios, large files uploaded to the server will have a ``large_file_sha1`` element added automatically to their ``file_info``.  However, when concatenating multiple sources, it may be impossible for the SDK to figure out the SHA-1 automatically.  In such cases, the SHA-1 can be provided using the ``large_file_sha1`` parameter to :meth:`b2sdk.v2.Bucket.create_file`, :meth:`b2sdk.v2.Bucket.concatenate` and their stream equivalents.  If the parameter is skipped or ``None``, the result file may not have the ``large_file_sha1`` value set.
+
+Note that the provided SHA-1 value is not verified.

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -63,6 +63,7 @@ from apiver_deps import CopySource, UploadSourceLocalFile, WriteIntent
 from apiver_deps import BucketRetentionSetting, FileRetentionSetting, LegalHold, RetentionMode, RetentionPeriod, \
     NO_RETENTION_FILE_SETTING
 from apiver_deps import ReplicationConfiguration, ReplicationRule
+from apiver_deps import LARGE_FILE_SHA1
 
 pytestmark = [pytest.mark.apiver(from_ver=1)]
 
@@ -250,6 +251,14 @@ class TestCaseWithBucket(TestBase):
     def _check_file_contents(self, file_name, expected_contents):
         contents = self._download_file(file_name)
         self.assertEqual(expected_contents, contents)
+
+    def _check_large_file_sha1(self, file_name, expected_sha1):
+        file_info = self.bucket.get_file_info_by_name(file_name).file_info
+        if expected_sha1:
+            assert LARGE_FILE_SHA1 in file_info
+            assert file_info[LARGE_FILE_SHA1] == expected_sha1
+        else:
+            assert LARGE_FILE_SHA1 not in file_info
 
     def _download_file(self, file_name):
         with FileSimulator.dont_check_encryption():
@@ -702,6 +711,7 @@ class TestCopyFile(TestCaseWithBucket):
         else:
             self.bucket.copy(file_id, 'hello_new.txt', offset=3, length=7)
         self._check_file_contents('hello_new.txt', b'lo worl')
+        self._check_large_file_sha1('hello_new.txt', None)
         expected = [('hello.txt', 11, 'upload', None), ('hello_new.txt', 7, 'upload', None)]
         self.assertBucketContents(expected, '', show_versions=True)
 
@@ -1121,6 +1131,7 @@ class TestUpload(TestCaseWithBucket):
         file_info = self.bucket.upload_bytes(data, 'file1')
         self.assertTrue(isinstance(file_info, VFileVersionInfo))
         self._check_file_contents('file1', data)
+        self._check_large_file_sha1('file1', None)
         self.assertEqual(file_info.server_side_encryption, SSE_NONE)
 
     def test_upload_bytes_file_retention(self):
@@ -1130,6 +1141,7 @@ class TestUpload(TestCaseWithBucket):
             data, 'file1', file_retention=retention, legal_hold=LegalHold.ON
         )
         self._check_file_contents('file1', data)
+        self._check_large_file_sha1('file1', None)
         self.assertEqual(retention, file_info.file_retention)
         self.assertEqual(LegalHold.ON, file_info.legal_hold)
 
@@ -1195,6 +1207,7 @@ class TestUpload(TestCaseWithBucket):
             write_file(path, data)
             file_info = self.bucket.upload_local_file(path, 'file1')
             self._check_file_contents('file1', data)
+            self._check_large_file_sha1('file1', None)
             self.assertTrue(isinstance(file_info, VFileVersionInfo))
             self.assertEqual(file_info.server_side_encryption, SSE_NONE)
             print(file_info.as_dict())
@@ -1253,8 +1266,9 @@ class TestUpload(TestCaseWithBucket):
     def test_upload_large(self):
         data = self._make_data(self.simulator.MIN_PART_SIZE * 3)
         progress_listener = StubProgressListener()
-        self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
+        print(self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener))
         self._check_file_contents('file1', data)
+        self._check_large_file_sha1('file1', hex_sha1_of_bytes(data))
         self.assertTrue(progress_listener.is_valid())
 
     def test_upload_local_large_file(self):
@@ -1264,6 +1278,7 @@ class TestUpload(TestCaseWithBucket):
             write_file(path, data)
             self.bucket.upload_local_file(path, 'file1')
             self._check_file_contents('file1', data)
+            self._check_large_file_sha1('file1', hex_sha1_of_bytes(data))
 
     def test_upload_local_large_file_over_10k_parts(self):
         pytest.skip('this test is really slow and impedes development')  # TODO: fix it
@@ -1273,6 +1288,7 @@ class TestUpload(TestCaseWithBucket):
             write_file(path, data)
             self.bucket.upload_local_file(path, 'file1')
             self._check_file_contents('file1', data)
+            self._check_large_file_sha1('file1', hex_sha1_of_bytes(data))
 
     def test_create_file_over_10k_parts(self):
         data = b'hello world' * 20000


### PR DESCRIPTION
With this change `large_file_sha1` entries are now added to `file_info` automatically if possible.  In advanced used cases the `large_file_sha1` can be provided manually to some of `Bucket`'s methods.