### PR TITLE
Additional tests for listing files / versions – edge case scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Infrastructure
+* Additional tests for listing files/versions
+
 ## [1.18.0] - 2022-09-20
 
 ### Added

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -2177,12 +2177,13 @@ class DecodeTests(DecodeTestsBase, TestCaseWithBucket):
 
 # Listing where every other response returns no entries and pointer to the next file
 
+
 class EmptyListBucketSimulator(BucketSimulator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Whenever we receive a list request, if it's the first time
         # for this particular ``start_file_name``, we'll return
-        # an empty response pointing to the same file as the next one.
+        # an empty response pointing to the same file.
         self.last_queried_file = None
 
     def list_file_versions(


### PR DESCRIPTION
The test checks whether empty response with `nextFileName` set is properly handled by the SDK. We provide a bucket implementation that ensures that every first request for a given file name returns no files and only points to the same file again (second request with the same filename results with an expected behaviour). Using that we're performing a standard set of tests for both `Bucket.ls` and `Bucket.list_versions`.