### PR TITLE
Additional tests for listing files / versions – edge case scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Infrastructure
+* Additional tests for listing files/versions
+
 ## [1.18.0] - 2022-09-20
 
 ### Added

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -45,7 +45,7 @@ Streaming interface
 
 Some object creation methods start writing data before reading the whole input (iterator). This can be used to write objects that do not have fully known contents without writing them first locally, so that they could be copied. Such usage pattern can be relevant to small devices which stream data to B2 from an external NAS, where caching large files such as media files or virtual machine images is not an option.
 
-Please see :ref:`advanced method support table <advanced_methods_support_table>` to see where streaming interface is supported. 
+Please see :ref:`advanced method support table <advanced_methods_support_table>` to see where streaming interface is supported.
 
 Continuation
 ============
@@ -184,7 +184,7 @@ Change the middle of the remote file
 For more information see :meth:`b2sdk.v2.Bucket.create_file`.
 
 
-Synthetize a file from local and remote parts
+Synthesize a file from local and remote parts
 =============================================
 
 This is useful for expert usage patterns such as:

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -2177,12 +2177,13 @@ class DecodeTests(DecodeTestsBase, TestCaseWithBucket):
 
 # Listing where every other response returns no entries and pointer to the next file
 
+
 class EmptyListBucketSimulator(BucketSimulator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Whenever we receive a list request, if it's the first time
         # for this particular ``start_file_name``, we'll return
-        # an empty response pointing to the same file as the next one.
+        # an empty response pointing to the same file.
         self.last_queried_file = None
 
     def list_file_versions(

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -2191,7 +2191,7 @@ class EmptyListBucketSimulator(BucketSimulator):
         account_auth_token,
         start_file_name=None,
         start_file_id=None,
-        max_file_count=None,
+        max_file_count=None,  # noqa
         prefix=None,
     ):
         if self.last_queried_file != start_file_name:
@@ -2201,7 +2201,7 @@ class EmptyListBucketSimulator(BucketSimulator):
             account_auth_token,
             start_file_name,
             start_file_id,
-            max_file_count,
+            1,  # Forcing only a single file per response.
             prefix,
         )
 
@@ -2209,7 +2209,7 @@ class EmptyListBucketSimulator(BucketSimulator):
         self,
         account_auth_token,
         start_file_name=None,
-        max_file_count=None,
+        max_file_count=None,  # noqa
         prefix=None,
     ):
         if self.last_queried_file != start_file_name:
@@ -2218,7 +2218,7 @@ class EmptyListBucketSimulator(BucketSimulator):
         return super().list_file_names(
             account_auth_token,
             start_file_name,
-            max_file_count,
+            1,  # Forcing only a single file per response.
             prefix,
         )
 


### PR DESCRIPTION
The test checks whether empty response with `nextFileName` is properly handled by the SDK. We provide a bucket implementation that ensures that every first request for a given file name returns no files and only points to the same file again. Using that we're performing a standard set of tests for both `Bucket.ls` and `Bucket.list_versions`.