### PR TITLE
Printing first N bytes when the received error is not a JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Authorizing a key for a single bucket ensures that this bucket is cached
 * `Bucket.ls` operation supports wildcard matching strings
 * Documentation for AbstractUploadSource and its children
-* `InvalidJsonResponse` when the received error is not a proper JSON document
+* `InvalidJsonResponse` when the received error is not a proper JSON document, or `PotentialS3EndpointPassedAsRealm` if the response `url` contained `//s3.`
 
 ### Fixed
 * Removed information about replication being in closed beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Authorizing a key for a single bucket ensures that this bucket is cached
 * `Bucket.ls` operation supports wildcard matching strings
 * Documentation for AbstractUploadSource and its children
+* `InvalidJsonResponse` when the received error is not a proper JSON document
 
 ### Fixed
 * Removed information about replication being in closed beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Authorizing a key for a single bucket ensures that this bucket is cached
 * `Bucket.ls` operation supports wildcard matching strings
 * Documentation for AbstractUploadSource and its children
-* `InvalidJsonResponse` when the received error is not a proper JSON document, or `PotentialS3EndpointPassedAsRealm` if the response `url` contained `//s3.`
+* `InvalidJsonResponse` when the received error is not a proper JSON document
+* Raising `PotentialS3EndpointPassedAsRealm` when a specific misconfiguration is suspected
 
 ### Fixed
 * Removed information about replication being in closed beta

--- a/b2sdk/_v3/exception.py
+++ b/b2sdk/_v3/exception.py
@@ -44,6 +44,7 @@ from b2sdk.exception import FileNameNotAllowed
 from b2sdk.exception import FileNotPresent
 from b2sdk.exception import FileSha1Mismatch
 from b2sdk.exception import InvalidAuthToken
+from b2sdk.exception import InvalidJsonResponse
 from b2sdk.exception import InvalidMetadataDirective
 from b2sdk.exception import InvalidRange
 from b2sdk.exception import InvalidUploadSource
@@ -123,6 +124,7 @@ __all__ = (
     'IncompleteSync',
     'InvalidArgument',
     'InvalidAuthToken',
+    'InvalidJsonResponse',
     'InvalidMetadataDirective',
     'InvalidRange',
     'InvalidUploadSource',

--- a/b2sdk/_v3/exception.py
+++ b/b2sdk/_v3/exception.py
@@ -54,6 +54,7 @@ from b2sdk.exception import MissingPart
 from b2sdk.exception import NonExistentBucket
 from b2sdk.exception import NotAllowedByAppKeyError
 from b2sdk.exception import PartSha1Mismatch
+from b2sdk.exception import PotentialS3EndpointPassedAsRealm
 from b2sdk.exception import RestrictedBucket
 from b2sdk.exception import RestrictedBucketMissing
 from b2sdk.exception import RetentionWriteError
@@ -136,6 +137,7 @@ __all__ = (
     'NotADirectory',
     'NotAllowedByAppKeyError',
     'PartSha1Mismatch',
+    'PotentialS3EndpointPassedAsRealm',
     'RestrictedBucket',
     'RestrictedBucketMissing',
     'RetentionWriteError',

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -540,6 +540,12 @@ class EnablingFileLockOnRestrictedBucket(B2Error):
         return "Turning on file lock for a restricted bucket is not allowed"
 
 
+class InvalidJsonResponse(B2SimpleError):
+    def __init__(self, content: bytes):
+        self.content = content
+        super().__init__('%s...' % self.content)
+
+
 @trace_call(logger)
 def interpret_b2_error(
     status: int,

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -541,9 +541,19 @@ class EnablingFileLockOnRestrictedBucket(B2Error):
 
 
 class InvalidJsonResponse(B2SimpleError):
+    UP_TO_BYTES_COUNT = 200
+
     def __init__(self, content: bytes):
         self.content = content
-        super().__init__('%s...' % self.content)
+        message = '%s' % self.content[:self.UP_TO_BYTES_COUNT]
+        if len(content) > self.UP_TO_BYTES_COUNT:
+            message += '...'
+
+        super().__init__(message)
+
+
+class PotentialS3EndpointPassedAsRealm(InvalidJsonResponse):
+    pass
 
 
 @trace_call(logger)

--- a/test/unit/b2http/test_b2http.py
+++ b/test/unit/b2http/test_b2http.py
@@ -15,7 +15,7 @@ import socket
 from ..test_base import TestBase
 
 import apiver_deps
-from apiver_deps_exception import BadDateFormat, BadJson, BrokenPipe, B2ConnectionError, ClockSkew, ConnectionReset, ServiceError, UnknownError, UnknownHost, TooManyRequests, InvalidJsonResponse, PotentialS3EndpointAsRealmPassed
+from apiver_deps_exception import BadDateFormat, BadJson, BrokenPipe, B2ConnectionError, ClockSkew, ConnectionReset, ServiceError, UnknownError, UnknownHost, TooManyRequests, InvalidJsonResponse, PotentialS3EndpointPassedAsRealm
 from apiver_deps import USER_AGENT
 from apiver_deps import B2Http
 from apiver_deps import B2HttpApiConfig
@@ -116,7 +116,7 @@ class TestTranslateErrors(TestBase):
         response.content = b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
         response.url = 'https://s3.us-west-000.backblazeb2.com'
 
-        with self.assertRaises(PotentialS3EndpointAsRealmPassed):
+        with self.assertRaises(PotentialS3EndpointPassedAsRealm):
             B2Http._translate_errors(lambda: response)
 
 

--- a/test/unit/b2http/test_b2http.py
+++ b/test/unit/b2http/test_b2http.py
@@ -15,7 +15,7 @@ import socket
 from ..test_base import TestBase
 
 import apiver_deps
-from apiver_deps_exception import BadDateFormat, BadJson, BrokenPipe, B2ConnectionError, ClockSkew, ConnectionReset, ServiceError, UnknownError, UnknownHost, TooManyRequests
+from apiver_deps_exception import BadDateFormat, BadJson, BrokenPipe, B2ConnectionError, ClockSkew, ConnectionReset, ServiceError, UnknownError, UnknownHost, TooManyRequests, InvalidJsonResponse
 from apiver_deps import USER_AGENT
 from apiver_deps import B2Http
 from apiver_deps import B2HttpApiConfig
@@ -97,6 +97,17 @@ class TestTranslateErrors(TestBase):
         response.content = b'{"status": 429, "code": "Too Many requests", "message": "retry after some time"}'
         with self.assertRaises(TooManyRequests):
             B2Http._translate_errors(lambda: response)
+
+    def test_invalid_json(self):
+        response = MagicMock()
+        response.status_code = 400
+        response.content = b'{' * 500
+
+        with self.assertRaises(InvalidJsonResponse) as error:
+            B2Http._translate_errors(lambda: response)
+
+            content_length = min(len(response.content), len(error.content))
+            self.assertEqual(response.content[:content_length], error.content[:content_length])
 
 
 class TestTranslateAndRetry(TestBase):


### PR DESCRIPTION
When someone tries to call `realm` with s3 endpoint like this:

```python
api = B2Api()
api.authorize_account('https://s3.us-west-000.backblazeb2.com', 'app-key-id', 'app-key')
```
(as was the case here: https://github.com/Backblaze/terraform-provider-b2/issues/33)

he'll receive the following error now:
```
Potential s3 endpoint passed as realm: b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<Error>\n    <Code>NotImplemented</Code>\n    <Message>Backblaze B2 does not support this API call.</Message>\n</Error>\n'
```

In other cases, we just wrap the JSON error:
```
Invalid json response: b'first-n-bytes-of-the-message'...
```