### PR TITLE
Add support for incremental upload and sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Authorizing a key for a single bucket ensures that this bucket is cached
 * `Bucket.ls` operation supports wildcard matching strings
 * Add `large_file_sha1` support
+* Add support for incremental upload and sync
 
 ### Infrastructure
 * Additional tests for listing files/versions

--- a/b2sdk/_v3/__init__.py
+++ b/b2sdk/_v3/__init__.py
@@ -184,6 +184,7 @@ from b2sdk.sync.report import SyncFileReporter
 from b2sdk.sync.report import SyncReport
 from b2sdk.sync.sync import KeepOrDeleteMode
 from b2sdk.sync.sync import Synchronizer
+from b2sdk.sync.sync import UploadMode
 from b2sdk.sync.encryption_provider import AbstractSyncEncryptionSettingsProvider
 from b2sdk.sync.encryption_provider import BasicSyncEncryptionSettingsProvider
 from b2sdk.sync.encryption_provider import ServerDefaultSyncEncryptionSettingsProvider

--- a/b2sdk/_v3/__init__.py
+++ b/b2sdk/_v3/__init__.py
@@ -61,6 +61,7 @@ from b2sdk.utils import (
     hex_sha1_of_bytes,
     hex_sha1_of_file,
     TempDir,
+    IncrementalHexDigester,
 )
 
 from b2sdk.utils import trace_call

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -12,6 +12,7 @@ import fnmatch
 import logging
 import pathlib
 
+from contextlib import suppress
 from typing import Optional, Tuple
 
 from .encryption.setting import EncryptionSetting, EncryptionSettingFactory
@@ -555,11 +556,9 @@ class Bucket(metaclass=B2TraceMeta):
         large_file_sha1 = sha1_sum
 
         if upload_mode == UploadMode.INCREMENTAL:
-            try:
+            with suppress(FileNotPresent):
                 existing_file_info = self.get_file_info_by_name(file_name)
-            except FileNotPresent:
-                pass
-            else:
+
                 sources = upload_source.get_incremental_sources(
                     existing_file_info,
                     self.api.session.account_info.get_absolute_minimum_part_size()

--- a/b2sdk/encryption/setting.py
+++ b/b2sdk/encryption/setting.py
@@ -218,6 +218,9 @@ class EncryptionSetting:
     def __repr__(self):
         return '<%s(%s, %s, %s)>' % (self.__class__.__name__, self.mode, self.algorithm, self.key)
 
+    def is_unknown(self):
+        return self.mode == EncryptionMode.NONE
+
 
 class EncryptionSettingFactory:
     # 2021-03-17: for the bucket the response of the server is:

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -8,7 +8,7 @@
 #
 ######################################################################
 
-from typing import Dict, Optional, Union, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Optional, Union, Tuple, TYPE_CHECKING
 import re
 from copy import deepcopy
 
@@ -102,7 +102,7 @@ class BaseFileVersion:
             return '%s%s' % (UNVERIFIED_CHECKSUM_PREFIX, content_sha1)
         return content_sha1
 
-    def _clone(self, **new_attributes: Dict[str, object]):
+    def _clone(self, **new_attributes: Any):
         """
         Create new instance based on the old one, overriding attributes with :code:`new_attributes`
         (only applies to arguments passed to __init__)
@@ -205,10 +205,9 @@ class BaseFileVersion:
         if self.content_sha1 and self.content_sha1 != "none":
             return self.content_sha1
         elif LARGE_FILE_SHA1 in self.file_info:
-            return self.file_info[LARGE_FILE_SHA1]
-        else:
-            # content SHA1 unknown
-            return None
+            return Sha1HexDigest(self.file_info[LARGE_FILE_SHA1])
+        # content SHA1 unknown
+        return None
 
 
 class FileVersion(BaseFileVersion):

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -13,12 +13,12 @@ import re
 from copy import deepcopy
 
 from .encryption.setting import EncryptionSetting, EncryptionSettingFactory
-from .replication.types import ReplicationStatus
-from .http_constants import FILE_INFO_HEADER_PREFIX_LOWER, SRC_LAST_MODIFIED_MILLIS
 from .file_lock import FileRetentionSetting, LegalHold, NO_RETENTION_FILE_SETTING
+from .http_constants import FILE_INFO_HEADER_PREFIX_LOWER, LARGE_FILE_SHA1, SRC_LAST_MODIFIED_MILLIS
 from .progress import AbstractProgressListener
+from .replication.types import ReplicationStatus
+from .utils import b2_url_decode, Sha1HexDigest
 from .utils.range_ import Range
-from .utils import b2_url_decode
 
 if TYPE_CHECKING:
     from .api import B2Api
@@ -196,6 +196,19 @@ class BaseFileVersion:
         m = self._TYPE_MATCHER.match(self.id_)
         assert m, self.id_
         return self._FILE_TYPE[int(m.group(1))]
+
+    def get_content_sha1(self) -> Optional[Sha1HexDigest]:
+        """
+        Get the file's content SHA1 hex digest from the header or, if its absent,
+        from the file info.  If both are missing, return None.
+        """
+        if self.content_sha1 and self.content_sha1 != "none":
+            return self.content_sha1
+        elif LARGE_FILE_SHA1 in self.file_info:
+            return self.file_info[LARGE_FILE_SHA1]
+        else:
+            # content SHA1 unknown
+            return None
 
 
 class FileVersion(BaseFileVersion):

--- a/b2sdk/http_constants.py
+++ b/b2sdk/http_constants.py
@@ -18,9 +18,19 @@ FILE_INFO_HEADER_PREFIX_LOWER = FILE_INFO_HEADER_PREFIX.lower()
 SRC_LAST_MODIFIED_MILLIS = 'src_last_modified_millis'
 LARGE_FILE_SHA1 = 'large_file_sha1'
 
+# SHA-1 hash key for large files
+LARGE_FILE_SHA1 = 'large_file_sha1'
+
 # Special X-Bz-Content-Sha1 value to verify checksum at the end
 HEX_DIGITS_AT_END = 'hex_digits_at_end'
 
 # Identifying SSE_C keys
 SSE_C_KEY_ID_FILE_INFO_KEY_NAME = 'sse_c_key_id'
 SSE_C_KEY_ID_HEADER = FILE_INFO_HEADER_PREFIX + SSE_C_KEY_ID_FILE_INFO_KEY_NAME
+
+# Default part sizes
+MEGABYTE = 1000 * 1000
+GIGABYTE = 1000 * MEGABYTE
+DEFAULT_MIN_PART_SIZE = 5 * MEGABYTE
+DEFAULT_RECOMMENDED_UPLOAD_PART_SIZE = 100 * MEGABYTE
+DEFAULT_MAX_PART_SIZE = 5 * GIGABYTE

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -671,7 +671,8 @@ class BucketSimulator:
         return self.file_id_to_file[file_id].as_upload_result(account_auth_token)
 
     def get_file_info_by_name(self, account_auth_token, file_name):
-        for ((name, id), file) in self.file_name_and_id_to_file.items():
+        # Sorting files by name and ID, so lower ID (newer upload) is returned first.
+        for ((name, id), file) in sorted(self.file_name_and_id_to_file.items()):
             if file_name == name:
                 return file.as_download_headers(account_auth_token_or_none=account_auth_token)
         raise FileNotPresent(file_id_or_name=file_name, bucket_name=self.bucket_name)

--- a/b2sdk/scan/folder.py
+++ b/b2sdk/scan/folder.py
@@ -15,7 +15,7 @@ import re
 import sys
 
 from abc import ABCMeta, abstractmethod
-from typing import Iterator
+from typing import Iterator, Optional
 
 from ..utils import fix_windows_path_limit, get_file_mtime, is_file_readable
 from .exception import EmptyDirectory, EnvironmentEncodingError, NotADirectory, UnableToCreateDirectory, UnsupportedFilename
@@ -52,7 +52,7 @@ class AbstractFolder(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def all_files(self, reporter: ProgressReport,
+    def all_files(self, reporter: Optional[ProgressReport],
                   policies_manager=DEFAULT_SCAN_MANAGER) -> Iterator[AbstractPath]:
         """
         Return an iterator over all of the files in the folder, in
@@ -124,7 +124,7 @@ class LocalFolder(AbstractFolder):
         """
         return 'local'
 
-    def all_files(self, reporter: ProgressReport,
+    def all_files(self, reporter: Optional[ProgressReport],
                   policies_manager=DEFAULT_SCAN_MANAGER) -> Iterator[LocalPath]:
         """
         Yield all files.
@@ -319,7 +319,7 @@ class B2Folder(AbstractFolder):
 
     def all_files(
         self,
-        reporter: ProgressReport,
+        reporter: Optional[ProgressReport],
         policies_manager: ScanPoliciesManager = DEFAULT_SCAN_MANAGER
     ) -> Iterator[B2Path]:
         """

--- a/b2sdk/sync/action.py
+++ b/b2sdk/sync/action.py
@@ -514,4 +514,4 @@ class LocalDeleteAction(AbstractAction):
         reporter.print_completion('delete ' + self.relative_name)
 
     def __str__(self) -> str:
-        return 'local_delete(%s)' % self.full_path
+        return 'local_delete(%s)' % (self.full_path,)

--- a/b2sdk/sync/policy.py
+++ b/b2sdk/sync/policy.py
@@ -18,7 +18,8 @@ from ..exception import DestFileNewer
 from ..scan.exception import InvalidArgument
 from ..scan.folder import AbstractFolder
 from ..scan.path import AbstractPath
-from .action import B2CopyAction, B2DeleteAction, B2DownloadAction, B2HideAction, B2UploadAction, LocalDeleteAction
+from ..transfer.outbound.upload_source import UploadMode
+from .action import B2CopyAction, B2DeleteAction, B2DownloadAction, B2HideAction, B2IncrementalUploadAction, B2UploadAction, LocalDeleteAction
 from .encryption_provider import SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER, AbstractSyncEncryptionSettingsProvider
 
 ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
@@ -62,6 +63,8 @@ class AbstractFileSyncPolicy(metaclass=ABCMeta):
         compare_version_mode: CompareVersionMode = CompareVersionMode.MODTIME,
         encryption_settings_provider:
         AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+        upload_mode: UploadMode = UploadMode.FULL,
+        absolute_minimum_part_size: int = None,
     ):
         """
         :param b2sdk.v2.AbstractPath source_path: source file object
@@ -74,6 +77,8 @@ class AbstractFileSyncPolicy(metaclass=ABCMeta):
         :param int compare_threshold: when comparing with size or time for sync
         :param b2sdk.v2.CompareVersionMode compare_version_mode: how to compare source and destination files
         :param b2sdk.v2.AbstractSyncEncryptionSettingsProvider encryption_settings_provider: encryption setting provider
+        :param b2sdk.v2.UploadMode upload_mode: file upload mode
+        :param int absolute_minimum_part_size: minimum file part size that can be uploaded to the server
         """
         self._source_path = source_path
         self._source_folder = source_folder
@@ -86,6 +91,8 @@ class AbstractFileSyncPolicy(metaclass=ABCMeta):
         self._now_millis = now_millis
         self._transferred = False
         self._encryption_settings_provider = encryption_settings_provider
+        self._upload_mode = upload_mode
+        self._absolute_minimum_part_size = absolute_minimum_part_size
 
     def _should_transfer(self):
         """
@@ -243,14 +250,27 @@ class UpPolicy(AbstractFileSyncPolicy):
     SOURCE_PREFIX = 'local://'
 
     def _make_transfer_action(self):
-        return B2UploadAction(
-            self._source_folder.make_full_path(self._source_path.relative_path),
-            self._source_path.relative_path,
-            self._dest_folder.make_full_path(self._source_path.relative_path),
-            self._get_source_mod_time(),
-            self._source_path.size,
-            self._encryption_settings_provider,
-        )
+        # Find out if we want to append with new bytes or replace completely
+        if self._upload_mode == UploadMode.INCREMENTAL and self._dest_path:
+            return B2IncrementalUploadAction(
+                self._source_folder.make_full_path(self._source_path.relative_path),
+                self._source_path.relative_path,
+                self._dest_folder.make_full_path(self._source_path.relative_path),
+                self._get_source_mod_time(),
+                self._source_path.size,
+                self._encryption_settings_provider,
+                self._dest_path.selected_version,
+                self._absolute_minimum_part_size,
+            )
+        else:
+            return B2UploadAction(
+                self._source_folder.make_full_path(self._source_path.relative_path),
+                self._source_path.relative_path,
+                self._dest_folder.make_full_path(self._source_path.relative_path),
+                self._get_source_mod_time(),
+                self._source_path.size,
+                self._encryption_settings_provider,
+            )
 
 
 class UpAndDeletePolicy(UpPolicy):

--- a/b2sdk/sync/policy.py
+++ b/b2sdk/sync/policy.py
@@ -64,21 +64,21 @@ class AbstractFileSyncPolicy(metaclass=ABCMeta):
         encryption_settings_provider:
         AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
         upload_mode: UploadMode = UploadMode.FULL,
-        absolute_minimum_part_size: int = None,
+        absolute_minimum_part_size: Optional[int] = None,
     ):
         """
-        :param b2sdk.v2.AbstractPath source_path: source file object
-        :param b2sdk.v2.AbstractFolder source_folder: source folder object
-        :param b2sdk.v2.AbstractPath dest_path: destination file object
-        :param b2sdk.v2.AbstractFolder dest_folder: destination folder object
-        :param int now_millis: current time in milliseconds
-        :param int keep_days: days to keep before delete
-        :param b2sdk.v2.NewerFileSyncMode newer_file_mode: setting which determines handling for destination files newer than on the source
-        :param int compare_threshold: when comparing with size or time for sync
-        :param b2sdk.v2.CompareVersionMode compare_version_mode: how to compare source and destination files
-        :param b2sdk.v2.AbstractSyncEncryptionSettingsProvider encryption_settings_provider: encryption setting provider
-        :param b2sdk.v2.UploadMode upload_mode: file upload mode
-        :param int absolute_minimum_part_size: minimum file part size that can be uploaded to the server
+        :param source_path: source file object
+        :param source_folder: source folder object
+        :param dest_path: destination file object
+        :param dest_folder: destination folder object
+        :param now_millis: current time in milliseconds
+        :param keep_days: days to keep before delete
+        :param newer_file_mode: setting which determines handling for destination files newer than on the source
+        :param compare_threshold: when comparing with size or time for sync
+        :param compare_version_mode: how to compare source and destination files
+        :param encryption_settings_provider: encryption setting provider
+        :param upload_mode: file upload mode
+        :param absolute_minimum_part_size: minimum file part size that can be uploaded to the server
         """
         self._source_path = source_path
         self._source_folder = source_folder
@@ -94,7 +94,7 @@ class AbstractFileSyncPolicy(metaclass=ABCMeta):
         self._upload_mode = upload_mode
         self._absolute_minimum_part_size = absolute_minimum_part_size
 
-    def _should_transfer(self):
+    def _should_transfer(self) -> bool:
         """
         Decide whether to transfer the file from the source to the destination.
         """

--- a/b2sdk/sync/policy_manager.py
+++ b/b2sdk/sync/policy_manager.py
@@ -8,10 +8,10 @@
 #
 ######################################################################
 
-from typing import Union
+from typing import Optional
 
-from ..scan.folder import AbstractFolder, B2Folder, LocalFolder
-from ..scan.path import AbstractPath, B2Path, LocalPath
+from ..scan.folder import AbstractFolder
+from ..scan.path import AbstractPath
 from ..transfer.outbound.upload_source import UploadMode
 from .policy import AbstractFileSyncPolicy, CompareVersionMode, CopyAndDeletePolicy, \
     CopyAndKeepDaysPolicy, CopyPolicy, DownAndDeletePolicy, DownAndKeepDaysPolicy, \
@@ -31,10 +31,10 @@ class SyncPolicyManager:
     def get_policy(
         self,
         sync_type: str,
-        source_path: Union[AbstractPath, B2Path, LocalPath, None],
-        source_folder: Union[AbstractFolder, B2Folder, LocalFolder],
-        dest_path: Union[AbstractPath, B2Path, LocalPath, None],
-        dest_folder: Union[AbstractFolder, B2Folder, LocalFolder],
+        source_path: Optional[AbstractPath],
+        source_folder: AbstractFolder,
+        dest_path: Optional[AbstractPath],
+        dest_folder: AbstractFolder,
         now_millis: int,
         delete: bool,
         keep_days: int,

--- a/b2sdk/sync/policy_manager.py
+++ b/b2sdk/sync/policy_manager.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from ..scan.path import AbstractPath
+from typing import Union
+
+from ..scan.folder import AbstractFolder, B2Folder, LocalFolder
+from ..scan.path import AbstractPath, B2Path, LocalPath
 from ..transfer.outbound.upload_source import UploadMode
 from .policy import AbstractFileSyncPolicy, CompareVersionMode, CopyAndDeletePolicy, \
     CopyAndKeepDaysPolicy, CopyPolicy, DownAndDeletePolicy, DownAndKeepDaysPolicy, \
@@ -28,10 +31,10 @@ class SyncPolicyManager:
     def get_policy(
         self,
         sync_type: str,
-        source_path: AbstractPath,
-        source_folder: str,
-        dest_path: AbstractPath,
-        dest_folder: str,
+        source_path: Union[AbstractPath, B2Path, LocalPath, None],
+        source_folder: Union[AbstractFolder, B2Folder, LocalFolder],
+        dest_path: Union[AbstractPath, B2Path, LocalPath, None],
+        dest_folder: Union[AbstractFolder, B2Folder, LocalFolder],
         now_millis: int,
         delete: bool,
         keep_days: int,
@@ -45,20 +48,20 @@ class SyncPolicyManager:
         """
         Return a policy object.
 
-        :param str sync_type: synchronization type
-        :param b2sdk.v2.AbstractPath source_path: source file
-        :param str source_folder: a source folder path
-        :param b2sdk.v2.AbstractPath dest_path: destination file
-        :param str dest_folder: a destination folder path
-        :param int now_millis: current time in milliseconds
-        :param bool delete: delete policy
-        :param int keep_days: keep for days policy
-        :param b2sdk.v2.NewerFileSyncMode newer_file_mode: setting which determines handling for destination files newer than on the source
-        :param int compare_threshold: difference between file modification time or file size
-        :param b2sdk.v2.CompareVersionMode compare_version_mode: setting which determines how to compare source and destination files
-        :param b2sdk.v2.AbstractSyncEncryptionSettingsProvider encryption_settings_provider: an object which decides which encryption to use (if any)
-        :param b2sdk.v2.UploadMode upload_mode: determines how file uploads are handled
-        :param int absolute_minimum_part_size: minimum file part size for large files
+        :param sync_type: synchronization type
+        :param source_path: source file
+        :param source_folder: a source folder path
+        :param dest_path: destination file
+        :param dest_folder: a destination folder path
+        :param now_millis: current time in milliseconds
+        :param delete: delete policy
+        :param keep_days: keep for days policy
+        :param newer_file_mode: setting which determines handling for destination files newer than on the source
+        :param compare_threshold: difference between file modification time or file size
+        :param compare_version_mode: setting which determines how to compare source and destination files
+        :param encryption_settings_provider: an object which decides which encryption to use (if any)
+        :param upload_mode: determines how file uploads are handled
+        :param absolute_minimum_part_size: minimum file part size for large files
         :return: a policy object
         """
         policy_class = self.get_policy_class(sync_type, delete, keep_days)

--- a/b2sdk/sync/policy_manager.py
+++ b/b2sdk/sync/policy_manager.py
@@ -9,9 +9,11 @@
 ######################################################################
 
 from ..scan.path import AbstractPath
-from .policy import CopyAndDeletePolicy, CopyAndKeepDaysPolicy, CopyPolicy, \
-    DownAndDeletePolicy, DownAndKeepDaysPolicy, DownPolicy, UpAndDeletePolicy, \
-    UpAndKeepDaysPolicy, UpPolicy
+from ..transfer.outbound.upload_source import UploadMode
+from .policy import AbstractFileSyncPolicy, CompareVersionMode, CopyAndDeletePolicy, \
+    CopyAndKeepDaysPolicy, CopyPolicy, DownAndDeletePolicy, DownAndKeepDaysPolicy, \
+    DownPolicy, NewerFileSyncMode, UpAndDeletePolicy, UpAndKeepDaysPolicy, UpPolicy
+from .encryption_provider import AbstractSyncEncryptionSettingsProvider
 
 
 class SyncPolicyManager:
@@ -25,19 +27,21 @@ class SyncPolicyManager:
 
     def get_policy(
         self,
-        sync_type,
+        sync_type: str,
         source_path: AbstractPath,
-        source_folder,
+        source_folder: str,
         dest_path: AbstractPath,
-        dest_folder,
-        now_millis,
-        delete,
-        keep_days,
-        newer_file_mode,
-        compare_threshold,
-        compare_version_mode,
-        encryption_settings_provider,
-    ):
+        dest_folder: str,
+        now_millis: int,
+        delete: bool,
+        keep_days: int,
+        newer_file_mode: NewerFileSyncMode,
+        compare_threshold: int,
+        compare_version_mode: CompareVersionMode,
+        encryption_settings_provider: AbstractSyncEncryptionSettingsProvider,
+        upload_mode: UploadMode,
+        absolute_minimum_part_size: int,
+    ) -> AbstractFileSyncPolicy:
         """
         Return a policy object.
 
@@ -53,6 +57,8 @@ class SyncPolicyManager:
         :param int compare_threshold: difference between file modification time or file size
         :param b2sdk.v2.CompareVersionMode compare_version_mode: setting which determines how to compare source and destination files
         :param b2sdk.v2.AbstractSyncEncryptionSettingsProvider encryption_settings_provider: an object which decides which encryption to use (if any)
+        :param b2sdk.v2.UploadMode upload_mode: determines how file uploads are handled
+        :param int absolute_minimum_part_size: minimum file part size for large files
         :return: a policy object
         """
         policy_class = self.get_policy_class(sync_type, delete, keep_days)
@@ -67,6 +73,8 @@ class SyncPolicyManager:
             compare_threshold,
             compare_version_mode,
             encryption_settings_provider,
+            upload_mode,
+            absolute_minimum_part_size,
         )
 
     def get_policy_class(self, sync_type, delete, keep_days):

--- a/b2sdk/sync/sync.py
+++ b/b2sdk/sync/sync.py
@@ -12,7 +12,7 @@ import concurrent.futures as futures
 import logging
 
 from enum import Enum, unique
-from typing import Optional, Union
+from typing import cast, Optional
 
 from ..bounded_queue_executor import BoundedQueueExecutor
 from ..scan.exception import InvalidArgument
@@ -152,8 +152,8 @@ class Synchronizer:
 
     def sync_folders(
         self,
-        source_folder: Union[AbstractFolder, LocalFolder, B2Folder],
-        dest_folder: Union[AbstractFolder, LocalFolder, B2Folder],
+        source_folder: AbstractFolder,
+        dest_folder: AbstractFolder,
         now_millis: int,
         reporter: Optional[SyncReport],
         encryption_settings_provider:
@@ -178,10 +178,10 @@ class Synchronizer:
 
         # For downloads, make sure that the target directory is there.
         if dest_type == 'local' and not self.dry_run:
-            dest_folder.ensure_present()
+            cast(LocalFolder, dest_folder).ensure_present()
 
         if source_type == 'local' and not self.allow_empty_source:
-            source_folder.ensure_non_empty()
+            cast(LocalFolder, source_folder).ensure_non_empty()
 
         # Make an executor to count files and run all of the actions. This is
         # not the same as the executor in the API object which is used for
@@ -203,9 +203,9 @@ class Synchronizer:
         # For bucket-to-bucket sync, the bucket for the API calls should be the destination.
         action_bucket = None
         if dest_type == 'b2':
-            action_bucket = dest_folder.bucket
+            action_bucket = cast(B2Folder, dest_folder).bucket
         elif source_type == 'b2':
-            action_bucket = source_folder.bucket
+            action_bucket = cast(B2Folder, source_folder).bucket
 
         # Schedule each of the actions.
         for action in self._make_folder_sync_actions(

--- a/b2sdk/transfer/emerge/planner/planner.py
+++ b/b2sdk/transfer/emerge/planner/planner.py
@@ -24,10 +24,12 @@ from b2sdk.transfer.emerge.planner.upload_subpart import (
     LocalSourceUploadSubpart,
     RemoteSourceUploadSubpart,
 )
+from b2sdk.http_constants import (
+    DEFAULT_MIN_PART_SIZE,
+    DEFAULT_MAX_PART_SIZE,
+    DEFAULT_RECOMMENDED_UPLOAD_PART_SIZE,
+)
 from b2sdk.utils import iterator_peek
-
-MEGABYTE = 1000 * 1000
-GIGABYTE = 1000 * MEGABYTE
 
 
 class UploadBuffer:
@@ -82,9 +84,6 @@ class UploadBuffer:
 
 class EmergePlanner:
     """ Creates a list of actions required for advanced creation of an object in the cloud from an iterator of write intent objects """
-    DEFAULT_MIN_PART_SIZE = 5 * MEGABYTE
-    DEFAULT_RECOMMENDED_UPLOAD_PART_SIZE = 100 * MEGABYTE
-    DEFAULT_MAX_PART_SIZE = 5 * GIGABYTE
 
     def __init__(
         self,
@@ -92,9 +91,9 @@ class EmergePlanner:
         recommended_upload_part_size=None,
         max_part_size=None,
     ):
-        self.min_part_size = min_part_size or self.DEFAULT_MIN_PART_SIZE
-        self.recommended_upload_part_size = recommended_upload_part_size or self.DEFAULT_RECOMMENDED_UPLOAD_PART_SIZE
-        self.max_part_size = max_part_size or self.DEFAULT_MAX_PART_SIZE
+        self.min_part_size = min_part_size or DEFAULT_MIN_PART_SIZE
+        self.recommended_upload_part_size = recommended_upload_part_size or DEFAULT_RECOMMENDED_UPLOAD_PART_SIZE
+        self.max_part_size = max_part_size or DEFAULT_MAX_PART_SIZE
         assert self.min_part_size <= self.recommended_upload_part_size <= self.max_part_size
 
     @classmethod
@@ -107,9 +106,9 @@ class EmergePlanner:
     ):
         if recommended_upload_part_size is None:
             recommended_upload_part_size = account_info.get_recommended_part_size()
-        if min_part_size is None and recommended_upload_part_size < cls.DEFAULT_MIN_PART_SIZE:
+        if min_part_size is None and recommended_upload_part_size < DEFAULT_MIN_PART_SIZE:
             min_part_size = recommended_upload_part_size
-        if max_part_size is None and recommended_upload_part_size > cls.DEFAULT_MAX_PART_SIZE:
+        if max_part_size is None and recommended_upload_part_size > DEFAULT_MAX_PART_SIZE:
             max_part_size = recommended_upload_part_size
         kwargs = {
             'min_part_size': min_part_size,

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -120,8 +120,6 @@ class UploadSourceLocalFileBase(AbstractUploadSource):
         self.local_path = local_path
         self.content_length = 0
         self.content_sha1 = content_sha1
-        self.digest = None
-        self.digest_progress = 0
         self.check_path_and_get_size()
 
     def check_path_and_get_size(self) -> None:

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -15,9 +15,10 @@ import os
 
 from abc import abstractmethod
 from enum import Enum, unique
-from typing import Callable, Optional, Union
+from typing import Callable, List, Optional, Union
 
 from b2sdk.exception import InvalidUploadSource
+from b2sdk.file_version import FileVersion
 from b2sdk.http_constants import DEFAULT_MIN_PART_SIZE
 from b2sdk.stream.range import RangeOfInputStream, wrap_with_range
 from b2sdk.transfer.outbound.copy_source import CopySource
@@ -222,7 +223,11 @@ class UploadSourceLocalFileRange(UploadSourceLocalFileBase):
 
 
 class UploadSourceLocalFile(UploadSourceLocalFileBase):
-    def get_incremental_sources(self, file_version, min_part_size=None):
+    def get_incremental_sources(
+        self,
+        file_version: FileVersion,
+        min_part_size: Optional[int] = None,
+    ) -> List[OutboundTransferSource]:
         """
         Split the upload into a copy and upload source constructing an incremental upload
 

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -142,17 +142,17 @@ class UploadSourceLocalFileBase(AbstractUploadSource):
     def get_content_length(self) -> int:
         return self.content_length
 
-    def _get_hexdigest(self) -> Sha1HexDigest:
-        with self.open() as fp:
-            return hex_sha1_of_stream(fp, self.content_length)
-
     def get_content_sha1(self) -> Optional[Sha1HexDigest]:
         if self.content_sha1 is None:
-            self.content_sha1 = self._get_hexdigest()
+            self.content_sha1 = self._hex_sha1_of_file()
         return self.content_sha1
 
     def open(self):
         return io.open(self.local_path, 'rb')
+
+    def _hex_sha1_of_file(self) -> Sha1HexDigest:
+        with self.open() as f:
+            return hex_sha1_of_stream(f, self.content_length)
 
     def is_sha1_known(self) -> bool:
         return self.content_sha1 is not None

--- a/b2sdk/utils/__init__.py
+++ b/b2sdk/utils/__init__.py
@@ -2,7 +2,7 @@
 #
 # File: b2sdk/utils/__init__.py
 #
-# Copyright 2019 Backblaze Inc. All Rights Reserved.
+# Copyright 2022 Backblaze Inc. All Rights Reserved.
 #
 # License https://www.backblaze.com/using_b2_code.html
 #

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -79,7 +79,7 @@ class TestDownload(IntegrationTestBase):
 
             source_sha1 = hex_sha1_of_file(source_small_file)
             assert source_sha1 == hex_sha1_of_file(target_small_file)
-        return f, source_sha1[0]
+        return f, source_sha1
 
     def test_small(self):
         bucket = self.create_bucket()

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -1461,9 +1461,7 @@ class TestUpload(TestCaseWithBucket):
                     # TODO: use .args[0] instead of [1][0] when we drop Python 3.7
                     assert len(call[1][0]) == expected_source_count
                     # Ensuring that the part sizes make sense.
-                    parts_sizes = [
-                        entry.get_content_length() for entry in call[1][0]
-                    ]
+                    parts_sizes = [entry.get_content_length() for entry in call[1][0]]
                     assert parts_sizes == expected_parts_sizes
                     if should_be_incremental:
                         # Ensuring that the first part is a copy.

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -1443,17 +1443,15 @@ class TestUpload(TestCaseWithBucket):
                 expected_source_count = 2 if should_be_incremental else 1
 
                 # is the result file expected to be a large file
-                expected_large_file = should_be_incremental or len(
-                    data
-                ) > self.simulator.MIN_PART_SIZE
+                expected_large_file = \
+                    should_be_incremental or \
+                    len(data) > self.simulator.MIN_PART_SIZE
 
                 write_file(path, data)
                 with mock.patch.object(
                     self.bucket, 'concatenate', wraps=self.bucket.concatenate
                 ) as mocked_concatenate:
-                    file_info = self.bucket.upload_local_file(
-                        path, 'file1', upload_mode=UploadMode.INCREMENTAL
-                    )
+                    self.bucket.upload_local_file(path, 'file1', upload_mode=UploadMode.INCREMENTAL)
                     mocked_concatenate.assert_called_once()
                     assert len(mocked_concatenate.call_args.args[0]) == expected_source_count
 

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -1459,7 +1459,9 @@ class TestUpload(TestCaseWithBucket):
                     mocked_concatenate.assert_called_once()
                     assert len(mocked_concatenate.call_args.args[0]) == expected_source_count
                     # Ensuring that the part sizes make sense.
-                    parts_sizes = [entry.get_content_length() for entry in mocked_concatenate.call_args.args[0]]
+                    parts_sizes = [
+                        entry.get_content_length() for entry in mocked_concatenate.call_args.args[0]
+                    ]
                     assert parts_sizes == expected_parts_sizes
                     if should_be_incremental:
                         # Ensuring that the first part is a copy.

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -66,6 +66,7 @@ from apiver_deps import BucketRetentionSetting, FileRetentionSetting, LegalHold,
     NO_RETENTION_FILE_SETTING
 from apiver_deps import ReplicationConfiguration, ReplicationRule
 from apiver_deps import LARGE_FILE_SHA1
+from apiver_deps import UploadMode
 
 pytestmark = [pytest.mark.apiver(from_ver=1)]
 
@@ -1413,6 +1414,54 @@ class TestUpload(TestCaseWithBucket):
             self.assertEqual(file_info.server_side_encryption, SSE_NONE)
             print(file_info.as_dict())
             self.assertEqual(file_info.as_dict()['serverSideEncryption'], {'mode': 'none'})
+
+    @pytest.mark.apiver(from_ver=2)
+    def test_upload_local_file_incremental(self):
+        with TempDir() as d:
+            path = os.path.join(d, 'file1')
+
+            small_data = b'Hello world!'
+            big_data = self._make_data(self.simulator.MIN_PART_SIZE * 3)
+            DATA = [
+                big_data,
+                big_data + small_data,
+                big_data + small_data + big_data,
+                small_data,
+                small_data + small_data,
+                small_data.upper() + small_data,
+            ]
+
+            last_data = None
+            for data in DATA:
+                # figure out if this particular upload should be incremental
+                should_be_incremental = (
+                    last_data and data.startswith(last_data) and
+                    len(last_data) >= self.simulator.MIN_PART_SIZE
+                )
+
+                # if it's incremental, then there should be two sources concatenated, otherwise one
+                expected_source_count = 2 if should_be_incremental else 1
+
+                # is the result file expected to be a large file
+                expected_large_file = should_be_incremental or len(
+                    data
+                ) > self.simulator.MIN_PART_SIZE
+
+                write_file(path, data)
+                with mock.patch.object(
+                    self.bucket, 'concatenate', wraps=self.bucket.concatenate
+                ) as mocked_concatenate:
+                    file_info = self.bucket.upload_local_file(
+                        path, 'file1', upload_mode=UploadMode.INCREMENTAL
+                    )
+                    mocked_concatenate.assert_called_once()
+                    assert len(mocked_concatenate.call_args.args[0]) == expected_source_count
+
+                self._check_file_contents('file1', data)
+                if expected_large_file:
+                    self._check_large_file_sha1('file1', hex_sha1_of_bytes(data))
+
+                last_data = data
 
     @pytest.mark.skipif(platform.system() == 'Windows', reason='no os.mkfifo() on Windows')
     def test_upload_fifo(self):

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -1457,15 +1457,18 @@ class TestUpload(TestCaseWithBucket):
                 ) as mocked_concatenate:
                     self.bucket.upload_local_file(path, 'file1', upload_mode=UploadMode.INCREMENTAL)
                     mocked_concatenate.assert_called_once()
-                    assert len(mocked_concatenate.call_args.args[0]) == expected_source_count
+                    call = mocked_concatenate.mock_calls[0]
+                    # TODO: use .args[0] instead of [1][0] when we drop Python 3.7
+                    assert len(call[1][0]) == expected_source_count
                     # Ensuring that the part sizes make sense.
                     parts_sizes = [
-                        entry.get_content_length() for entry in mocked_concatenate.call_args.args[0]
+                        entry.get_content_length() for entry in call[1][0]
                     ]
                     assert parts_sizes == expected_parts_sizes
                     if should_be_incremental:
                         # Ensuring that the first part is a copy.
-                        self.assertIsInstance(mocked_concatenate.call_args.args[0][0], CopySource)
+                        # Order of indices: pick arguments, pick first argument, first element of the first argument.
+                        self.assertIsInstance(call[1][0][0], CopySource)
 
                 self._check_file_contents('file1', data)
                 if expected_large_file:

--- a/test/unit/internal/test_emerge_planner.py
+++ b/test/unit/internal/test_emerge_planner.py
@@ -8,11 +8,11 @@
 #
 ######################################################################
 
-from b2sdk.transfer.emerge.planner.planner import (
-    EmergePlanner,
+from b2sdk.http_constants import (
     GIGABYTE,
     MEGABYTE,
 )
+from b2sdk.transfer.emerge.planner.planner import EmergePlanner
 from b2sdk.transfer.emerge.planner.part_definition import (
     CopyEmergePartDefinition,
     UploadEmergePartDefinition,

--- a/test/unit/sync/fixtures.py
+++ b/test/unit/sync/fixtures.py
@@ -10,7 +10,8 @@
 
 import pytest
 
-from apiver_deps import DEFAULT_SCAN_MANAGER, POLICY_MANAGER, CompareVersionMode, KeepOrDeleteMode, NewerFileSyncMode, Synchronizer
+import apiver_deps
+from apiver_deps import DEFAULT_SCAN_MANAGER, POLICY_MANAGER, CompareVersionMode, KeepOrDeleteMode, NewerFileSyncMode, Synchronizer, UploadMode
 
 
 @pytest.fixture(scope='session')
@@ -25,19 +26,39 @@ def synchronizer_factory():
         compare_version_mode=CompareVersionMode.MODTIME,
         compare_threshold=None,
         sync_policy_manager=POLICY_MANAGER,
+        upload_mode=UploadMode.FULL,
+        absolute_minimum_part_size=None,
     ):
-        return Synchronizer(
-            1,
-            policies_manager=policies_manager,
-            dry_run=dry_run,
-            allow_empty_source=allow_empty_source,
-            newer_file_mode=newer_file_mode,
-            keep_days_or_delete=keep_days_or_delete,
-            keep_days=keep_days,
-            compare_version_mode=compare_version_mode,
-            compare_threshold=compare_threshold,
-            sync_policy_manager=sync_policy_manager,
-        )
+        if apiver_deps.V < 2:
+            assert upload_mode == UploadMode.FULL, "upload_mode not supported in apiver < 2"
+            assert absolute_minimum_part_size is None, "absolute_minimum_part_size not supported in apiver < 2"
+            return Synchronizer(
+                1,
+                policies_manager=policies_manager,
+                dry_run=dry_run,
+                allow_empty_source=allow_empty_source,
+                newer_file_mode=newer_file_mode,
+                keep_days_or_delete=keep_days_or_delete,
+                keep_days=keep_days,
+                compare_version_mode=compare_version_mode,
+                compare_threshold=compare_threshold,
+                sync_policy_manager=sync_policy_manager,
+            )
+        else:
+            return Synchronizer(
+                1,
+                policies_manager=policies_manager,
+                dry_run=dry_run,
+                allow_empty_source=allow_empty_source,
+                newer_file_mode=newer_file_mode,
+                keep_days_or_delete=keep_days_or_delete,
+                keep_days=keep_days,
+                compare_version_mode=compare_version_mode,
+                compare_threshold=compare_threshold,
+                sync_policy_manager=sync_policy_manager,
+                upload_mode=upload_mode,
+                absolute_minimum_part_size=absolute_minimum_part_size,
+            )
 
     return get_synchronizer
 

--- a/test/unit/sync/fixtures.py
+++ b/test/unit/sync/fixtures.py
@@ -29,36 +29,29 @@ def synchronizer_factory():
         upload_mode=UploadMode.FULL,
         absolute_minimum_part_size=None,
     ):
+        kwargs = {}
         if apiver_deps.V < 2:
             assert upload_mode == UploadMode.FULL, "upload_mode not supported in apiver < 2"
             assert absolute_minimum_part_size is None, "absolute_minimum_part_size not supported in apiver < 2"
-            return Synchronizer(
-                1,
-                policies_manager=policies_manager,
-                dry_run=dry_run,
-                allow_empty_source=allow_empty_source,
-                newer_file_mode=newer_file_mode,
-                keep_days_or_delete=keep_days_or_delete,
-                keep_days=keep_days,
-                compare_version_mode=compare_version_mode,
-                compare_threshold=compare_threshold,
-                sync_policy_manager=sync_policy_manager,
-            )
         else:
-            return Synchronizer(
-                1,
-                policies_manager=policies_manager,
-                dry_run=dry_run,
-                allow_empty_source=allow_empty_source,
-                newer_file_mode=newer_file_mode,
-                keep_days_or_delete=keep_days_or_delete,
-                keep_days=keep_days,
-                compare_version_mode=compare_version_mode,
-                compare_threshold=compare_threshold,
-                sync_policy_manager=sync_policy_manager,
+            kwargs = dict(
                 upload_mode=upload_mode,
                 absolute_minimum_part_size=absolute_minimum_part_size,
             )
+
+        return Synchronizer(
+            1,
+            policies_manager=policies_manager,
+            dry_run=dry_run,
+            allow_empty_source=allow_empty_source,
+            newer_file_mode=newer_file_mode,
+            keep_days_or_delete=keep_days_or_delete,
+            keep_days=keep_days,
+            compare_version_mode=compare_version_mode,
+            compare_threshold=compare_threshold,
+            sync_policy_manager=sync_policy_manager,
+            **kwargs
+        )
 
     return get_synchronizer
 

--- a/test/unit/sync/test_sync.py
+++ b/test/unit/sync/test_sync.py
@@ -12,7 +12,7 @@ from unittest import mock
 from enum import Enum
 from functools import partial
 
-from apiver_deps import UpPolicy, B2DownloadAction, AbstractSyncEncryptionSettingsProvider, UploadSourceLocalFileRange, UploadSourceLocalFile, SyncPolicyManager
+from apiver_deps import UpPolicy, B2DownloadAction, AbstractSyncEncryptionSettingsProvider, UploadSourceLocalFileRange, UploadSourceLocalFile, SyncPolicyManager, CopySource
 from apiver_deps_exception import DestFileNewer, InvalidArgument
 from apiver_deps import KeepOrDeleteMode, NewerFileSyncMode, CompareVersionMode, FileVersion
 import pytest
@@ -935,6 +935,8 @@ class TestSynchronizer:
             )
         ]
         assert len(bucket.mock_calls[0].args[0]) == 2 if should_be_incremental else 1
+        if should_be_incremental:
+            assert isinstance(bucket.mock_calls[0].args[0][0], CopySource)
 
 
 class TstEncryptionSettingsProvider(AbstractSyncEncryptionSettingsProvider):
@@ -963,7 +965,3 @@ class TstEncryptionSettingsProvider(AbstractSyncEncryptionSettingsProvider):
 
     def get_setting_for_download(self, *a, **kw):
         """overwritten in __init__"""
-
-
-class TestIncrementalUploadAction:
-    pass

--- a/test/unit/sync/test_sync.py
+++ b/test/unit/sync/test_sync.py
@@ -924,7 +924,9 @@ class TestSynchronizer:
                 mock.patch.object(
                     UploadSourceLocalFile, 'check_path_and_get_size', check_path_and_get_size
                 ),
-                mock.patch.object(UploadSourceLocalFile, '_get_hexdigest', return_value=local_sha1),
+                mock.patch.object(
+                    UploadSourceLocalFile, '_hex_sha1_of_file', return_value=local_sha1
+                ),
                 mock.patch.object(
                     UploadSourceLocalFileRange, 'check_path_and_get_size', check_path_and_get_size
                 ),


### PR DESCRIPTION
Whenever a file is uploaded or synced with incremental sync flag, and the file was only appended, current version from B2 is copied and only the new part is uploaded.