### PR TITLE
Wrapping raw `OSError` exceptions and checking when we're unable to work with the destination file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Removed information about replication being in closed beta
-
-### Fixed
 * Raw OSError exceptions are not thrown when using `DownloadedFile.save_to` to a path that doesn't exist, is a directory or the user doesn't have permissions to write to
 
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Authorizing a key for a single bucket ensures that this bucket is cached
 * `Bucket.ls` operation supports wildcard matching strings
 
+### Fixed
+* Raw OSError exceptions are not thrown when using `DownloadedFile.save_to` to a path that doesn't exist, is a directory or the user doesn't have permissions to write to
+
 ### Infrastructure
 * Additional tests for listing files/versions
 * Ensured that changelog validation only happens on pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Removed information about replication being in closed beta
-* Raw OSError exceptions are not thrown when using `DownloadedFile.save_to` to a path that doesn't exist, is a directory or the user doesn't have permissions to write to
+* Don't throw raw OSError exceptions when using `DownloadedFile.save_to` to a path that doesn't exist, is a directory or the user doesn't have permissions to write to
 
 ### Infrastructure
 * Additional tests for listing files/versions

--- a/b2sdk/_v3/exception.py
+++ b/b2sdk/_v3/exception.py
@@ -37,6 +37,9 @@ from b2sdk.exception import Conflict
 from b2sdk.exception import ConnectionReset
 from b2sdk.exception import CopyArgumentsMismatch
 from b2sdk.exception import DestFileNewer
+from b2sdk.exception import DestinationDirectoryDoesntAllowOperation
+from b2sdk.exception import DestinationDirectoryDoesntExist
+from b2sdk.exception import DestinationIsADirectory
 from b2sdk.exception import DisablingFileLockNotSupported
 from b2sdk.exception import DuplicateBucketName
 from b2sdk.exception import FileAlreadyHidden
@@ -112,6 +115,9 @@ __all__ = (
     'CopyArgumentsMismatch',
     'CorruptAccountInfo',
     'DestFileNewer',
+    'DestinationDirectoryDoesntAllowOperation',
+    'DestinationDirectoryDoesntExist',
+    'DestinationIsADirectory',
     'DisablingFileLockNotSupported',
     'DuplicateBucketName',
     'EmptyDirectory',

--- a/b2sdk/_v3/exception.py
+++ b/b2sdk/_v3/exception.py
@@ -40,7 +40,7 @@ from b2sdk.exception import DestFileNewer
 from b2sdk.exception import DestinationDirectoryDoesntAllowOperation
 from b2sdk.exception import DestinationDirectoryDoesntExist
 from b2sdk.exception import DestinationIsADirectory
-from b2sdk.exception import DestinationIsNotADirectory
+from b2sdk.exception import DestinationParentIsNotADirectory
 from b2sdk.exception import DisablingFileLockNotSupported
 from b2sdk.exception import DuplicateBucketName
 from b2sdk.exception import FileAlreadyHidden
@@ -121,7 +121,7 @@ __all__ = (
     'DestinationDirectoryDoesntAllowOperation',
     'DestinationDirectoryDoesntExist',
     'DestinationIsADirectory',
-    'DestinationIsNotADirectory',
+    'DestinationParentIsNotADirectory',
     'DisablingFileLockNotSupported',
     'DuplicateBucketName',
     'EmptyDirectory',

--- a/b2sdk/_v3/exception.py
+++ b/b2sdk/_v3/exception.py
@@ -40,6 +40,7 @@ from b2sdk.exception import DestFileNewer
 from b2sdk.exception import DestinationDirectoryDoesntAllowOperation
 from b2sdk.exception import DestinationDirectoryDoesntExist
 from b2sdk.exception import DestinationIsADirectory
+from b2sdk.exception import DestinationIsNotADirectory
 from b2sdk.exception import DisablingFileLockNotSupported
 from b2sdk.exception import DuplicateBucketName
 from b2sdk.exception import FileAlreadyHidden
@@ -120,6 +121,7 @@ __all__ = (
     'DestinationDirectoryDoesntAllowOperation',
     'DestinationDirectoryDoesntExist',
     'DestinationIsADirectory',
+    'DestinationIsNotADirectory',
     'DisablingFileLockNotSupported',
     'DuplicateBucketName',
     'EmptyDirectory',

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -540,6 +540,22 @@ class EnablingFileLockOnRestrictedBucket(B2Error):
         return "Turning on file lock for a restricted bucket is not allowed"
 
 
+class DestinationDirectoryError(B2Error):
+    pass
+
+
+class DestinationDirectoryDoesntExist(DestinationDirectoryError):
+    pass
+
+
+class DestinationIsADirectory(DestinationDirectoryError):
+    pass
+
+
+class DestinationDirectoryDoesntAllowOperation(DestinationDirectoryError):
+    pass
+
+
 @trace_call(logger)
 def interpret_b2_error(
     status: int,

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -564,6 +564,10 @@ class DestinationDirectoryDoesntExist(DestinationDirectoryError):
     pass
 
 
+class DestinationIsNotADirectory(DestinationDirectoryError):
+    pass
+
+
 class DestinationIsADirectory(DestinationDirectoryError):
     pass
 

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -564,7 +564,7 @@ class DestinationDirectoryDoesntExist(DestinationDirectoryError):
     pass
 
 
-class DestinationIsNotADirectory(DestinationDirectoryError):
+class DestinationParentIsNotADirectory(DestinationDirectoryError):
     pass
 
 

--- a/b2sdk/transfer/inbound/downloaded_file.py
+++ b/b2sdk/transfer/inbound/downloaded_file.py
@@ -25,7 +25,7 @@ from b2sdk.exception import (
     DestinationDirectoryDoesntAllowOperation,
     DestinationDirectoryDoesntExist,
     DestinationIsADirectory,
-    DestinationIsNotADirectory,
+    DestinationParentIsNotADirectory,
     TruncatedOutput,
 )
 from b2sdk.utils import set_file_mtime
@@ -81,7 +81,7 @@ class MtimeUpdatedFile(io.IOBase):
                 raise DestinationDirectoryDoesntExist()
 
             if not path.parent.is_dir():
-                raise DestinationIsNotADirectory()
+                raise DestinationParentIsNotADirectory()
 
             # This ensures consistency on *nix and Windows. Windows doesn't seem to raise ``IsADirectoryError`` at all,
             # so with this we actually can differentiate between permissions errors and target being a directory.

--- a/b2sdk/transfer/inbound/downloaded_file.py
+++ b/b2sdk/transfer/inbound/downloaded_file.py
@@ -10,6 +10,7 @@
 
 import io
 import logging
+import pathlib
 from typing import Optional, Tuple, TYPE_CHECKING
 
 from requests.models import Response
@@ -73,6 +74,12 @@ class MtimeUpdatedFile(io.IOBase):
         return self.file.tell()
 
     def __enter__(self):
+        path = pathlib.Path(self.path_)
+        # This ensures consistency on *nix and Windows. Windows doesn't seem to raise ``IsADirectoryError`` at all,
+        # so with this we actually can differentiate between permissions errors and target being a directory.
+        if path.exists() and path.is_dir():
+            raise DestinationIsADirectory()
+
         try:
             self.file = open(self.path_, self.mode, buffering=self.buffering)
         except FileNotFoundError as ex:

--- a/b2sdk/utils/__init__.py
+++ b/b2sdk/utils/__init__.py
@@ -16,7 +16,6 @@ import re
 import shutil
 import tempfile
 import time
-import concurrent.futures as futures
 from decimal import Decimal
 from urllib.parse import quote, unquote_plus
 

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -2516,12 +2516,7 @@ class TestDownloadLocalDirectoryIssues(TestCaseWithBucket):
             target_file = pathlib.Path(temp_dir) / 'existing-directory'
             os.makedirs(target_file, exist_ok=True)
 
-            expected_exception = DestinationIsADirectory
-            if platform.system() == 'Windows':
-                # Windows doesn't raise IsADirectoryError, raises PermissionError instead
-                expected_exception = DestinationDirectoryDoesntAllowOperation
-
-            with self.assertRaises(expected_exception):
+            with self.assertRaises(DestinationIsADirectory):
                 self.bucket.download_file_by_name(self.file_version.file_name).save_to(target_file)
 
     @pytest.mark.apiver(from_ver=2)

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -30,7 +30,7 @@ from apiver_deps_exception import (
     DestinationDirectoryDoesntAllowOperation,
     DestinationDirectoryDoesntExist,
     DestinationIsADirectory,
-    DestinationIsNotADirectory,
+    DestinationParentIsNotADirectory,
     DisablingFileLockNotSupported,
     FileSha1Mismatch,
     InvalidAuthToken,
@@ -2527,7 +2527,7 @@ class TestDownloadLocalDirectoryIssues(TestCaseWithBucket):
             some_file.write_bytes(b'i-am-a-file')
             target_file = some_file / 'save-target'
 
-            with self.assertRaises(DestinationIsNotADirectory):
+            with self.assertRaises(DestinationParentIsNotADirectory):
                 self.bucket.download_file_by_name(self.file_version.file_name).save_to(target_file)
 
     @pytest.mark.apiver(from_ver=2)

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -7,10 +7,12 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+import contextlib
 import io
 from contextlib import suppress
 from io import BytesIO
 import os
+import pathlib
 import platform
 import unittest.mock as mock
 
@@ -25,6 +27,9 @@ from apiver_deps_exception import (
     B2RequestTimeoutDuringUpload,
     BadRequest,
     BucketIdNotFound,
+    DestinationDirectoryDoesntAllowOperation,
+    DestinationDirectoryDoesntExist,
+    DestinationIsADirectory,
     DisablingFileLockNotSupported,
     FileSha1Mismatch,
     InvalidAuthToken,
@@ -2413,6 +2418,49 @@ class TestAuthorizeForBucket(TestCaseWithBucket):
 
         with self.assertRaises(RestrictedBucketMissing):
             self.api.authorize_account('production', key.id_, key.application_key)
+
+
+class TestDownloadLocalDirectoryIssues(TestCaseWithBucket):
+    def setUp(self):
+        super().setUp()
+        self.file_version = self.bucket.upload_bytes(b'test-data', 'file1')
+        self.bytes_io = io.BytesIO()
+        self.progress_listener = StubProgressListener()
+
+    @pytest.mark.apiver(from_ver=2)
+    def test_download_file_to_unknown_directory(self):
+        with TempDir() as temp_dir:
+            target_file = pathlib.Path(temp_dir) / 'non-existing-directory' / 'some-file'
+            with self.assertRaises(DestinationDirectoryDoesntExist):
+                self.bucket.download_file_by_name(self.file_version.file_name).save_to(target_file)
+
+    @pytest.mark.apiver(from_ver=2)
+    def test_download_file_targeting_directory(self):
+        with TempDir() as temp_dir:
+            target_file = pathlib.Path(temp_dir) / 'existing-directory'
+            os.makedirs(target_file, exist_ok=True)
+            with self.assertRaises(DestinationIsADirectory):
+                self.bucket.download_file_by_name(self.file_version.file_name).save_to(target_file)
+
+    @pytest.mark.apiver(from_ver=2)
+    def test_download_file_no_access_to_directory(self):
+        chain = contextlib.ExitStack()
+        temp_dir = chain.enter_context(TempDir())
+
+        with chain:
+            target_directory = pathlib.Path(temp_dir) / 'impossible-directory'
+
+            os.makedirs(target_directory, exist_ok=True)
+            # Don't allow any operation on this directory. Used explicitly, as the documentation
+            # states that on some platforms passing mode to `makedirs` may be ignored.
+            os.chmod(target_directory, mode=0)
+
+            # Ensuring that whenever we exit this context, our directory will be removable.
+            chain.push(lambda *args, **kwargs: os.chmod(target_directory, mode=0o777))
+
+            target_file = target_directory / 'target_file'
+            with self.assertRaises(DestinationDirectoryDoesntAllowOperation):
+                self.bucket.download_file_by_name(self.file_version.file_name).save_to(target_file)
 
 
 # Listing where every other response returns no entries and pointer to the next file

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -30,6 +30,7 @@ from apiver_deps_exception import (
     DestinationDirectoryDoesntAllowOperation,
     DestinationDirectoryDoesntExist,
     DestinationIsADirectory,
+    DestinationIsNotADirectory,
     DisablingFileLockNotSupported,
     FileSha1Mismatch,
     InvalidAuthToken,
@@ -2517,6 +2518,16 @@ class TestDownloadLocalDirectoryIssues(TestCaseWithBucket):
             os.makedirs(target_file, exist_ok=True)
 
             with self.assertRaises(DestinationIsADirectory):
+                self.bucket.download_file_by_name(self.file_version.file_name).save_to(target_file)
+
+    @pytest.mark.apiver(from_ver=2)
+    def test_download_file_targeting_directory_is_a_file(self):
+        with TempDir() as temp_dir:
+            some_file = pathlib.Path(temp_dir) / 'existing-file'
+            some_file.write_bytes(b'i-am-a-file')
+            target_file = some_file / 'save-target'
+
+            with self.assertRaises(DestinationIsNotADirectory):
                 self.bucket.download_file_by_name(self.file_version.file_name).save_to(target_file)
 
     @pytest.mark.apiver(from_ver=2)


### PR DESCRIPTION
Closes https://github.com/Backblaze/B2_Command_Line_Tool/issues/618