### PR TITLE
chore: build python wheels as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Infrastructure
 * Remove dependency from `arrow`
+* Build Python wheels for distribution
 
 ## [1.20.0] - 2023-03-23
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -169,11 +169,11 @@ def cover(session):
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def build(session):
     """Build the distribution."""
-    # TODO: consider using wheel as well
     session.run('pip', 'install', *REQUIREMENTS_BUILD)
     session.run('python', 'setup.py', 'check', '--metadata', '--strict')
     session.run('rm', '-rf', 'build', 'dist', 'b2sdk.egg-info', external=True)
     session.run('python', 'setup.py', 'sdist', *session.posargs)
+    session.run('python', 'setup.py', 'bdist_wheel', *session.posargs)
 
     # Set outputs for GitHub Actions
     if CI:

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,7 @@ REQUIREMENTS_TEST = [
     'pyfakefs==4.5.6',
     'pytest-xdist==2.5.0',
 ]
-REQUIREMENTS_BUILD = ['setuptools>=20.2']
+REQUIREMENTS_BUILD = ['setuptools>=20.2', 'wheel>=0.40']
 
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = [


### PR DESCRIPTION
Doesn't yet use the modern PEP517 approach, since that's a much larger refactor in tooling and choices than adding the ability create wheels.