### PR TITLE
Remove dependency from tqdm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Circular symlinks no longer cause infinite loops when syncing a folder
+* Remove dependency from tqdm - projects like B2CLI should require it directly
 
 ## [1.21.0] - 2023-04-17
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 importlib-metadata>=3.3.0; python_version < '3.8'
 logfury>=1.0.1,<2.0.0
 requests>=2.9.1,<3.0.0
-tqdm>=4.5.0,<5.0.0


### PR DESCRIPTION
Projects like B2CLI should require it directly. The sdk generally works fine without that dependency which pulls its own dependencies and it is a problem for some projects. We'll continue to support classes that use tqdm.

Any existing installations should keep their dependency in their venv and new versions of the CLI as well as any other console applications should depend on tqdm directly, if they choose to use it.