### PR TITLE
fix pydantic validation compatiblity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Require `typing_extensions` on Python 3.11 (already required on earlier versinons) for better compatibility with pydantic v2
+
 ## [1.22.1] - 2023-07-24
 
 ### Fixed

--- a/b2sdk/raw_api.py
+++ b/b2sdk/raw_api.py
@@ -17,9 +17,9 @@ from logging import getLogger
 from typing import Any
 
 try:
-    from typing import NotRequired, TypedDict
-except ImportError:
     from typing_extensions import NotRequired, TypedDict
+except ImportError:
+    from typing import NotRequired, TypedDict
 
 from b2sdk.http_constants import FILE_INFO_HEADER_PREFIX
 from b2sdk.utils.docs import ensure_b2sdk_doc_urls

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ importlib-metadata>=3.3.0; python_version < '3.8'
 logfury>=1.0.1,<2.0.0
 requests>=2.9.1,<3.0.0
 tqdm>=4.5.0,<5.0.0
-typing-extensions>=4.7.1; python_version < '3.11'
+typing-extensions>=4.7.1; python_version < '3.12'


### PR DESCRIPTION
Pydantic now requires typing_extensions use on all pre-3.12 Python versions.
See
https://github.com/pydantic/pydantic/pull/6370/files#diff-4b71c6b75773e0ee81bdfe8a88a4f2d4eb9eba8b0548ccb190a7a6adffec3d07R293-R294 for details.