### PR TITLE
File info by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Add `get_file_info_by_name` to the B2Api class
 
 ### Fixed
 * Require `typing_extensions` on Python 3.11 (already required on earlier versinons) for better compatibility with pydantic v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 * Add `get_file_info_by_name` to the B2Api class
 
 ### Fixed

--- a/b2sdk/api.py
+++ b/b2sdk/api.py
@@ -587,6 +587,18 @@ class B2Api(metaclass=B2TraceMeta):
             self.session.get_file_info_by_id(file_id)
         )
 
+    def get_file_info_by_name(self, bucket_name: str, file_name: str) -> FileVersion:
+        """
+        Gets info about file version. Similar to `get-file-info` but 
+        takes the bucket name and file name instead of file id.
+
+        :param str file_id: the id of the file whose info will be retrieved.
+        """
+        return self.file_version_factory.from_api_response(
+            self.session.get_file_info_by_name(bucket_name, file_name),
+            force_action='folder',
+        )
+
     def check_bucket_name_restrictions(self, bucket_name: str):
         """
         Check to see if the allowed field from authorize-account has a bucket restriction.

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -488,23 +488,48 @@ class FileVersionFactory:
                "replicationStatus": "completed"
            }
 
+        or this:
+
+        .. code-block:: python
+
+            {
+                "content-length": 11, 
+                "content-type": "b2/x-auto", 
+                "x-bz-content-sha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed", 
+                "x-bz-upload-timestamp": 5000, 
+                "x-bz-file-id": "9999", 
+                "x-bz-file-name": "file"
+            }
+
         into a :py:class:`b2sdk.v2.FileVersion` object.
 
         """
         assert file_version_dict.get('action') is None or force_action is None, \
             'action was provided by both info_dict and function argument'
         action = file_version_dict.get('action') or force_action
-        file_name = file_version_dict['fileName']
-        id_ = file_version_dict['fileId']
+
+        file_version_dict['action'] = action
+
+        file_name = file_version_dict.get('fileName', file_version_dict.get('x-bz-file-name'))
+        id_ = file_version_dict.get('fileId', file_version_dict.get('x-bz-file-id'))
+
+        if file_name is None:
+            raise ValueError('no fileName or file')
+        if id_ is None:
+            raise ValueError('no fileId or x-bz-file-id')
+
         if 'size' in file_version_dict:
             size = file_version_dict['size']
         elif 'contentLength' in file_version_dict:
             size = file_version_dict['contentLength']
+        elif 'content-length' in file_version_dict:
+            size = file_version_dict['content-length']
         else:
             raise ValueError('no size or contentLength')
-        upload_timestamp = file_version_dict.get('uploadTimestamp')
-        content_type = file_version_dict.get('contentType')
-        content_sha1 = file_version_dict.get('contentSha1')
+
+        upload_timestamp = file_version_dict.get('uploadTimestamp', file_version_dict.get('x-bz-upload-timestamp'))
+        content_type = file_version_dict.get('contentType', file_version_dict.get('content-type'))
+        content_sha1 = file_version_dict.get('contentSha1', file_version_dict.get('x-bz-content-sha1'))
         content_md5 = file_version_dict.get('contentMd5')
         file_info = file_version_dict.get('fileInfo')
         server_side_encryption = EncryptionSettingFactory.from_file_version_dict(file_version_dict)
@@ -525,8 +550,8 @@ class FileVersionFactory:
             content_sha1,
             file_info,
             upload_timestamp,
-            file_version_dict['accountId'],
-            file_version_dict['bucketId'],
+            file_version_dict.get('accountId'),
+            file_version_dict.get('bucketId'),
             action,
             content_md5,
             server_side_encryption,

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -508,23 +508,24 @@ class FileVersionFactory:
             'action was provided by both info_dict and function argument'
         action = file_version_dict.get('action') or force_action
 
-        file_version_dict['action'] = action
+        if force_action is not None:
+            file_version_dict['action'] = force_action
 
         file_name = file_version_dict.get('fileName', file_version_dict.get('x-bz-file-name'))
         id_ = file_version_dict.get('fileId', file_version_dict.get('x-bz-file-id'))
 
         if file_name is None:
             raise ValueError('no fileName or file')
+        
         if id_ is None:
             raise ValueError('no fileId or x-bz-file-id')
 
-        if 'size' in file_version_dict:
-            size = file_version_dict['size']
-        elif 'contentLength' in file_version_dict:
-            size = file_version_dict['contentLength']
-        elif 'content-length' in file_version_dict:
-            size = file_version_dict['content-length']
-        else:
+        size = file_version_dict.get('size')
+        if size is None:
+            size = file_version_dict.get('contentLength') 
+        if size is None:
+            size = file_version_dict.get('content-length')
+        if size is None:
             raise ValueError('no size or contentLength')
 
         upload_timestamp = file_version_dict.get('uploadTimestamp', file_version_dict.get('x-bz-upload-timestamp'))

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -516,21 +516,27 @@ class FileVersionFactory:
 
         if file_name is None:
             raise ValueError('no fileName or file')
-        
+
         if id_ is None:
             raise ValueError('no fileId or x-bz-file-id')
 
         size = file_version_dict.get('size')
+
         if size is None:
-            size = file_version_dict.get('contentLength') 
+            size = file_version_dict.get('contentLength')
         if size is None:
             size = file_version_dict.get('content-length')
+
         if size is None:
             raise ValueError('no size or contentLength')
 
-        upload_timestamp = file_version_dict.get('uploadTimestamp', file_version_dict.get('x-bz-upload-timestamp'))
+        upload_timestamp = file_version_dict.get(
+            'uploadTimestamp', file_version_dict.get('x-bz-upload-timestamp')
+        )
         content_type = file_version_dict.get('contentType', file_version_dict.get('content-type'))
-        content_sha1 = file_version_dict.get('contentSha1', file_version_dict.get('x-bz-content-sha1'))
+        content_sha1 = file_version_dict.get(
+            'contentSha1', file_version_dict.get('x-bz-content-sha1')
+        )
         content_md5 = file_version_dict.get('contentMd5')
         file_info = file_version_dict.get('fileInfo')
         server_side_encryption = EncryptionSettingFactory.from_file_version_dict(file_version_dict)

--- a/test/unit/api/test_api.py
+++ b/test/unit/api/test_api.py
@@ -97,6 +97,37 @@ class TestApi:
             assert isinstance(result, VFileVersion)
             assert result == created_file
 
+    def test_get_file_info_by_name(self):
+        self._authorize_account()
+        bucket = self.api.create_bucket('bucket1', 'allPrivate')
+        bucket.upload_bytes(
+            b'hello world',
+            'file',
+        )
+        result = self.api.get_file_info_by_name('bucket1', 'file')
+        assert result.as_dict() == {
+            'fileId': '9999',
+            'fileName': 'file',
+            'fileInfo': {},
+            'serverSideEncryption': {
+                'mode': 'none'
+            },
+            'legalHold': None,
+            'fileRetention': {
+                'mode': None,
+                'retainUntilTimestamp': None
+            },
+            'cacheControl': None,
+            'size': 11,
+            'uploadTimestamp': 5000,
+            'contentType': 'b2/x-auto',
+            'contentSha1': '2aae6c35c94fcfb415dbe95f408b9ce91ee846ed',
+            'replicationStatus': None,
+            'accountId': None,
+            'bucketId': None,
+            'action': 'folder',
+        }
+
     @pytest.mark.parametrize(
         'expected_delete_bucket_output',
         [


### PR DESCRIPTION
I included the file info by name method to the API. This is related to https://github.com/Backblaze/B2_Command_Line_Tool/issues/440 and I will follow up with another PR, updating the CLI tool.

I am not sure whether I am using the force_action parameter correctly:

```
return self.file_version_factory.from_api_response(
            self.session.get_file_info_by_name(bucket_name, file_name),
            force_action='folder',
        )
```

I did not manage to find what are allowed values for `action` so I picked something that seemed reasonable (as in: "I am listing the folder"). Please review my usage of force_action and let me know if there is a better way to handle this case

Probably the whole `def from_api_response(self, file_version_dict, force_action=None)` should have a better documentation and type hints. 

