### PR TITLE
Cache control bugfix

### DIFF
--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -128,7 +128,6 @@ class BaseFileVersion:
             'file_retention': self.file_retention,
             'legal_hold': self.legal_hold,
             'replication_status': self.replication_status,
-            'cache_control': self.cache_control,
         }  # yapf: disable
 
     def as_dict(self):
@@ -140,7 +139,6 @@ class BaseFileVersion:
             'serverSideEncryption': self.server_side_encryption.as_dict(),
             'legalHold': self.legal_hold.value,
             'fileRetention': self.file_retention.as_dict(),
-            'cacheControl': self.cache_control,
         }
 
         if self.size is not None:
@@ -516,7 +514,7 @@ class FileVersionFactory:
         replication_status_value = file_version_dict.get('replicationStatus')
         replication_status = replication_status_value and ReplicationStatus[
             replication_status_value.upper()]
-        cache_control = file_version_dict.get('cacheControl')
+        cache_control = (file_info or {}).get('b2-cache-control')
 
         return self.FILE_VERSION_CLASS(
             self.api,

--- a/b2sdk/large_file/unfinished_large_file.py
+++ b/b2sdk/large_file/unfinished_large_file.py
@@ -38,7 +38,7 @@ class UnfinishedLargeFile:
         self.encryption = EncryptionSettingFactory.from_file_version_dict(file_dict)
         self.file_retention = FileRetentionSetting.from_file_version_dict(file_dict)
         self.legal_hold = LegalHold.from_file_version_dict(file_dict)
-        self.cache_control = file_dict.get('cacheControl')
+        self.cache_control = (self.file_info or {}).get('b2-cache-control')
 
     def __repr__(self):
         return f'<{self.__class__.__name__} {self.bucket_id} {self.file_name}>'

--- a/b2sdk/raw_api.py
+++ b/b2sdk/raw_api.py
@@ -771,7 +771,8 @@ class B2RawHTTPApi(AbstractRawApi):
             kwargs['custom_upload_timestamp'] = custom_upload_timestamp
 
         if cache_control is not None:
-            kwargs['cacheControl'] = cache_control
+            file_info = file_info or {}
+            file_info['b2-cache-control'] = cache_control
 
         return self._post_json(
             api_url,
@@ -1061,7 +1062,8 @@ class B2RawHTTPApi(AbstractRawApi):
             kwargs['fileRetention'] = file_retention.serialize_to_json_for_request()
 
         if cache_control is not None:
-            kwargs['cacheControl'] = cache_control
+            file_info = file_info or {}
+            file_info['b2-cache-control'] = cache_control
 
         try:
             return self._post_json(

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -299,7 +299,6 @@ class FileSimulator:
             action=self.action,
             uploadTimestamp=self.upload_timestamp,
             replicationStatus=self.replication_status and self.replication_status.value,
-            cacheControl=self.cache_control,
         )  # yapf: disable
         if self.server_side_encryption is not None:
             result['serverSideEncryption'
@@ -321,7 +320,6 @@ class FileSimulator:
             action=self.action,
             uploadTimestamp=self.upload_timestamp,
             replicationStatus=self.replication_status and self.replication_status.value,
-            cacheControl=self.cache_control,
         )  # yapf: disable
         if self.server_side_encryption is not None:
             result['serverSideEncryption'
@@ -346,7 +344,6 @@ class FileSimulator:
             fileInfo=self.file_info,
             uploadTimestamp=self.upload_timestamp,
             replicationStatus=self.replication_status and self.replication_status.value,
-            cacheControl=self.cache_control,
         )  # yapf: disable
         if self.server_side_encryption is not None:
             result['serverSideEncryption'

--- a/test/integration/test_raw_api.py
+++ b/test/integration/test_raw_api.py
@@ -443,7 +443,7 @@ def raw_api_test_helper(raw_api, should_cleanup_old_buckets):
     # b2_copy_file
     print('b2_copy_file')
     copy_file_name = 'test_copy.txt'
-    raw_api.copy_file(api_url, account_auth_token, file_id, copy_file_name)
+    raw_api.copy_file(api_url, account_auth_token, file_id, copy_file_name, cache_control="private, max-age=3600")
 
     # b2_get_file_info_by_id
     print('b2_get_file_info_by_id')

--- a/test/unit/api/test_api.py
+++ b/test/unit/api/test_api.py
@@ -94,7 +94,6 @@ class TestApi:
                     'mode': 'none'
                 },
                 'uploadTimestamp': 5000,
-                'cacheControl': 'private, max-age=3600',
             }
         else:
             assert isinstance(result, VFileVersion)
@@ -121,7 +120,6 @@ class TestApi:
                 'mode': None,
                 'retainUntilTimestamp': None
             },
-            'cacheControl': None,
             'size': 11,
             'uploadTimestamp': 5000,
             'contentType': 'b2/x-auto',
@@ -160,7 +158,6 @@ class TestApi:
                 'mode': None,
                 'retainUntilTimestamp': None
             },
-            'cacheControl': None,
             'size': 0,
             'uploadTimestamp': 5001,
             'contentSha1': 'none',


### PR DESCRIPTION
`B2RawHTTPApi` had a bug in how it passes `cache-control` parameter. See the API docs:

- https://www.backblaze.com/apidocs/b2-copy-file
- https://www.backblaze.com/apidocs/b2-start-large-file
- https://www.backblaze.com/apidocs/b2-list-unfinished-large-files
- https://www.backblaze.com/apidocs/b2-list-file-versions

None of these calls accept `cacheControl` argument or return `cacheControl` in the response. Cache control info is always in `fileInfo` structure, as `b2-cache-control` field.

The effect is that currently (before this PR) some `Bucket` methods (e.g. `upload_local_file()`) fail when `cache_control` argument is passed. Also, fetched file info will always have empty `cache_control`, even if it shouldn't be.