### PR TITLE
fix invalid escape sequences (python 3.12 SyntaxWarning)

### DIFF
--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -219,7 +219,7 @@ class FileVersion(BaseFileVersion):
     """
     A structure which represents a version of a file (in B2 cloud).
 
-    :ivar str ~.id\_: ``fileId``
+    :ivar str ~.id_: ``fileId``
     :ivar str ~.file_name: full file name (with path)
     :ivar ~.size: size in bytes, can be ``None`` (unknown)
     :ivar str ~.content_type: RFC 822 content type, for example ``"application/octet-stream"``

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -1159,7 +1159,7 @@ class RawSimulator(AbstractRawApi):
     DOWNLOAD_URL_MATCHER = re.compile(
         DOWNLOAD_URL + '(?:' + '|'.join(
             (
-                '/b2api/v[0-9]+/b2_download_file_by_id\?fileId=(?P<file_id>[^/]+)',
+                r'/b2api/v[0-9]+/b2_download_file_by_id\?fileId=(?P<file_id>[^/]+)',
                 '/file/(?P<bucket_name>[^/]+)/(?P<file_name>.+)',
             )
         ) + ')$'

--- a/b2sdk/v2/file_version.py
+++ b/b2sdk/v2/file_version.py
@@ -27,7 +27,7 @@ class FileVersion(v3.FileVersion):
     """
     A structure which represents a version of a file (in B2 cloud).
 
-    :ivar str ~.id\_: ``fileId``
+    :ivar str ~.id_: ``fileId``
     :ivar str ~.file_name: full file name (with path)
     :ivar ~.size: size in bytes, can be ``None`` (unknown)
     :ivar str ~.content_type: RFC 822 content type, for example ``"application/octet-stream"``

--- a/changelog.d/458.fixed.md
+++ b/changelog.d/458.fixed.md
@@ -1,0 +1,1 @@
+Fix escape sequence warnings present in python 3.12.


### PR DESCRIPTION
I don't see any reason to not do this (nothing in sphinx?).

As referenced in https://github.com/Backblaze/b2-sdk-python/issues/458