### PR TITLE
Add filters to `Bucket.ls`

### DIFF
--- a/b2sdk/_v3/__init__.py
+++ b/b2sdk/_v3/__init__.py
@@ -257,3 +257,6 @@ from b2sdk.http_constants import (
 )
 from b2sdk.session import B2Session
 from b2sdk.utils.thread_pool import ThreadPoolMixin
+
+# filter
+from b2sdk.filter import FilterType, Filter, include, exclude

--- a/b2sdk/_v3/__init__.py
+++ b/b2sdk/_v3/__init__.py
@@ -259,4 +259,4 @@ from b2sdk.session import B2Session
 from b2sdk.utils.thread_pool import ThreadPoolMixin
 
 # filter
-from b2sdk.filter import FilterType, Filter, include, exclude
+from b2sdk.filter import FilterType, Filter

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -371,7 +371,7 @@ class Bucket(metaclass=B2TraceMeta):
         recursive: bool = False,
         fetch_count: int | None = LIST_FILE_NAMES_MAX_LIMIT,
         with_wildcard: bool = False,
-        filters: Sequence[Filter] | None = None,
+        filters: Sequence[Filter] = (),
     ):
         """
         Pretend that folders exist and yields the information about the files in a folder.

--- a/b2sdk/filter.py
+++ b/b2sdk/filter.py
@@ -1,3 +1,12 @@
+######################################################################
+#
+# File: b2sdk/filter.py
+#
+# Copyright 2024 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
 from __future__ import annotations
 
 import fnmatch

--- a/b2sdk/filter.py
+++ b/b2sdk/filter.py
@@ -37,8 +37,16 @@ class Filter:
 class FilterMatcher:
     """
     Holds a list of filters and matches a string (i.e. file name) against them.
+
+    The order of filters matters. The *last* matching filter decides whether
+    the string is included or excluded. If no filter matches, the string is
+    included by default.
+
     If the given list of filters contains only INCLUDE filters, then it is
-    assumed that all files are excluded by default.
+    assumed that all files are excluded by default. In this case, an additional
+    EXCLUDE filter is prepended to the list.
+
+    :param filters: list of filters
     """
 
     def __init__(self, filters: Sequence[Filter]):

--- a/b2sdk/filter.py
+++ b/b2sdk/filter.py
@@ -35,6 +35,12 @@ def exclude(pattern: str) -> Filter:
 
 
 class FilterMatcher:
+    """
+    Holds a list of filters and matches a string (i.e. file name) against them.
+    If the given list of filters contains only INCLUDE filters, then it is
+    assumed that all files are excluded by default.
+    """
+
     def __init__(self, filters: Sequence[Filter]):
         if filters and all(filter_.type == FilterType.INCLUDE for filter_ in filters):
             filters = [Filter(type=FilterType.EXCLUDE, pattern="*"), *filters]

--- a/b2sdk/filter.py
+++ b/b2sdk/filter.py
@@ -10,8 +10,9 @@
 from __future__ import annotations
 
 import fnmatch
+from dataclasses import dataclass
 from enum import Enum
-from typing import NamedTuple, Sequence
+from typing import Sequence
 
 
 class FilterType(Enum):
@@ -19,7 +20,8 @@ class FilterType(Enum):
     EXCLUDE = "exclude"
 
 
-class Filter(NamedTuple):
+@dataclass
+class Filter:
     type: FilterType
     pattern: str
 

--- a/b2sdk/filter.py
+++ b/b2sdk/filter.py
@@ -25,13 +25,13 @@ class Filter:
     type: FilterType
     pattern: str
 
+    @classmethod
+    def include(cls, pattern: str) -> Filter:
+        return cls(type=FilterType.INCLUDE, pattern=pattern)
 
-def include(pattern: str) -> Filter:
-    return Filter(type=FilterType.INCLUDE, pattern=pattern)
-
-
-def exclude(pattern: str) -> Filter:
-    return Filter(type=FilterType.EXCLUDE, pattern=pattern)
+    @classmethod
+    def exclude(cls, pattern: str) -> Filter:
+        return cls(type=FilterType.EXCLUDE, pattern=pattern)
 
 
 class FilterMatcher:

--- a/b2sdk/filter.py
+++ b/b2sdk/filter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import fnmatch
+from enum import Enum
+from typing import NamedTuple, Sequence
+
+
+class FilterType(Enum):
+    INCLUDE = "include"
+    EXCLUDE = "exclude"
+
+
+class Filter(NamedTuple):
+    type: FilterType
+    pattern: str
+
+
+def include(pattern: str) -> Filter:
+    return Filter(type=FilterType.INCLUDE, pattern=pattern)
+
+
+def exclude(pattern: str) -> Filter:
+    return Filter(type=FilterType.EXCLUDE, pattern=pattern)
+
+
+class FilterMatcher:
+    def __init__(self, filters: Sequence[Filter] | None = None):
+        if not filters:
+            filters = []
+        elif all(filter_.type == FilterType.INCLUDE for filter_ in filters):
+            filters = [Filter(type=FilterType.EXCLUDE, pattern="*"), *filters]
+
+        self.filters = filters
+
+    def match(self, s: str) -> bool:
+        include_file = True
+        for filter_ in self.filters:
+            matched = fnmatch.fnmatchcase(s, filter_.pattern)
+            if matched and filter_.type == FilterType.INCLUDE:
+                include_file = True
+            elif matched and filter_.type == FilterType.EXCLUDE:
+                include_file = False
+
+        return include_file

--- a/b2sdk/filter.py
+++ b/b2sdk/filter.py
@@ -35,10 +35,8 @@ def exclude(pattern: str) -> Filter:
 
 
 class FilterMatcher:
-    def __init__(self, filters: Sequence[Filter] | None = None):
-        if not filters:
-            filters = []
-        elif all(filter_.type == FilterType.INCLUDE for filter_ in filters):
+    def __init__(self, filters: Sequence[Filter]):
+        if filters and all(filter_.type == FilterType.INCLUDE for filter_ in filters):
             filters = [Filter(type=FilterType.EXCLUDE, pattern="*"), *filters]
 
         self.filters = filters

--- a/changelog.d/+bucket_ls_filters.added.md
+++ b/changelog.d/+bucket_ls_filters.added.md
@@ -1,1 +1,1 @@
-Added support for filters to `Bucket.ls()`.
+Add support for filters to `Bucket.ls()`.

--- a/changelog.d/+bucket_ls_filters.added.md
+++ b/changelog.d/+bucket_ls_filters.added.md
@@ -1,0 +1,1 @@
+Added support for filters to `Bucket.ls()`.

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -100,7 +100,9 @@ from apiver_deps import (
     UploadSourceBytes,
     UploadSourceLocalFile,
     WriteIntent,
+    exclude,
     hex_sha1_of_bytes,
+    include,
 )
 
 pytestmark = [pytest.mark.apiver(from_ver=1)]
@@ -785,6 +787,227 @@ class TestLs(TestCaseWithBucket):
         actual = [
             (info.file_name, info.size, info.action, folder)
             for (info, folder) in self.bucket_ls('b/a.txt', recursive=True, with_wildcard=True)
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_wildcard_matching(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'a')
+        self.bucket.upload_bytes(data, 'b/1/test-1.txt')
+        self.bucket.upload_bytes(data, 'b/2/test-2.csv')
+        self.bucket.upload_bytes(data, 'b/2/test-3.txt')
+        self.bucket.upload_bytes(data, 'b/3/test-4.jpg')
+        self.bucket.upload_bytes(data, 'b/3/test-4.txt')
+        self.bucket.upload_bytes(data, 'b/3/test-5.txt')
+        expected = [
+            ('b/1/test-1.txt', len(data), 'upload', None),
+            ('b/2/test-3.txt', len(data), 'upload', None),
+            ('b/3/test-4.txt', len(data), 'upload', None),
+            ('b/3/test-5.txt', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls('b/', recursive=True, filters=[include("*.txt")])
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_wildcard_matching_including_root(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'b/1/test.csv')
+        self.bucket.upload_bytes(data, 'b/1/test.txt')
+        self.bucket.upload_bytes(data, 'b/2/test.tsv')
+        self.bucket.upload_bytes(data, 'b/2/test.txt')
+        self.bucket.upload_bytes(data, 'b/3/test.txt')
+        self.bucket.upload_bytes(data, 'test.txt')
+        self.bucket.upload_bytes(data, 'test.csv')
+
+        expected = [
+            ('b/1/test.txt', len(data), 'upload', None),
+            ('b/2/test.txt', len(data), 'upload', None),
+            ('b/3/test.txt', len(data), 'upload', None),
+            ('test.txt', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('*.txt')])
+        ]
+        self.assertEqual(expected, actual)
+
+        expected = [
+            ('b/1/test.csv', len(data), 'upload', None),
+            ('b/2/test.tsv', len(data), 'upload', None),
+            ('test.csv', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[exclude('*.txt')])
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_single_character_matching(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'a')
+        self.bucket.upload_bytes(data, 'b/2/test.csv')
+        self.bucket.upload_bytes(data, 'b/2/test.txt')
+        self.bucket.upload_bytes(data, 'b/2/test.tsv')
+
+        expected = [
+            ('b/2/test.csv', len(data), 'upload', None),
+            ('b/2/test.tsv', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info,
+                 folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.?sv')])
+        ]
+        self.assertEqual(expected, actual)
+
+        expected = [
+            ('a', len(data), 'upload', None),
+            ('b/2/test.txt', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info,
+                 folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.?sv')])
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_sequence_matching(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'a')
+        self.bucket.upload_bytes(data, 'b/2/test.csv')
+        self.bucket.upload_bytes(data, 'b/2/test.ksv')
+        self.bucket.upload_bytes(data, 'b/2/test.tsv')
+
+        expected = [
+            ('b/2/test.csv', len(data), 'upload', None),
+            ('b/2/test.tsv', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info,
+                 folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.[tc]sv')])
+        ]
+        self.assertEqual(expected, actual)
+
+        expected = [
+            ('a', len(data), 'upload', None),
+            ('b/2/test.ksv', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info,
+                 folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.[tc]sv')])
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_negative_sequence_matching(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'a')
+        self.bucket.upload_bytes(data, 'b/2/test.csv')
+        self.bucket.upload_bytes(data, 'b/2/test.ksv')
+        self.bucket.upload_bytes(data, 'b/2/test.tsv')
+
+        expected = [
+            ('b/2/test.tsv', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info,
+                 folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.[!ck]sv')])
+        ]
+        self.assertEqual(expected, actual)
+
+        expected = [
+            ('a', len(data), 'upload', None),
+            ('b/2/test.csv', len(data), 'upload', None),
+            ('b/2/test.ksv', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info,
+                 folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.[!ck]sv')])
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_matching_exact_filename(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'b/a.txt')
+        self.bucket.upload_bytes(data, 'b/b.txt')
+
+        expected = [
+            ('b/a.txt', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('b/a.txt')])
+        ]
+        self.assertEqual(expected, actual)
+
+        expected = [
+            ('b/b.txt', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[exclude('b/a.txt')])
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_mixed_with_wildcards(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'a.csv')
+        self.bucket.upload_bytes(data, 'a.txt')
+        self.bucket.upload_bytes(data, 'b/a-1.csv')
+        self.bucket.upload_bytes(data, 'b/a-1.txt')
+        self.bucket.upload_bytes(data, 'b/a-2.csv')
+        self.bucket.upload_bytes(data, 'b/a-2.txt')
+        self.bucket.upload_bytes(data, 'b/a-a.csv')
+        self.bucket.upload_bytes(data, 'b/a-a.txt')
+        self.bucket.upload_bytes(data, 'b/a.csv')
+        self.bucket.upload_bytes(data, 'b/a.txt')
+
+        expected = [
+            ('a.txt', len(data), 'upload', None),
+            ('b/a-1.txt', len(data), 'upload', None),
+            ('b/a-a.txt', len(data), 'upload', None),
+            ('b/a.txt', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls('*.txt',
+                                                 recursive=True,
+                                                 with_wildcard=True,
+                                                 filters=[exclude('*-2.txt')])
+        ]
+        self.assertEqual(expected, actual)
+
+        expected = [
+            ('b/a-1.csv', len(data), 'upload', None),
+            ('b/a-1.txt', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls('b/?-[1234567890].*',
+                                                 recursive=True,
+                                                 with_wildcard=True,
+                                                 filters=[exclude('*-2.*')])
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_filters_combination(self):
+        data = b'hello world'
+        self.bucket.upload_bytes(data, 'a.txt')
+        self.bucket.upload_bytes(data, 'b/a-1.csv')
+        self.bucket.upload_bytes(data, 'b/a-1.txt')
+
+        expected = [
+            ('a.txt', len(data), 'upload', None),
+            ('b/a-1.csv', len(data), 'upload', None),
+        ]
+        actual = [
+            (info.file_name, info.size, info.action, folder)
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('b/*'), exclude('*.txt'), include('a.txt')])
         ]
         self.assertEqual(expected, actual)
 

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -82,6 +82,7 @@ from apiver_deps import (
     FakeResponse,
     FileRetentionSetting,
     FileSimulator,
+    Filter,
     InMemoryCache,
     LargeFileUploadState,
     LegalHold,
@@ -100,9 +101,7 @@ from apiver_deps import (
     UploadSourceBytes,
     UploadSourceLocalFile,
     WriteIntent,
-    exclude,
     hex_sha1_of_bytes,
-    include,
 )
 
 pytestmark = [pytest.mark.apiver(from_ver=1)]
@@ -806,8 +805,11 @@ class TestLs(TestCaseWithBucket):
             ('b/3/test-5.txt', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls('b/', recursive=True, filters=[include("*.txt")])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                'b/',
+                recursive=True,
+                filters=[Filter.include("*.txt")],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -829,7 +831,7 @@ class TestLs(TestCaseWithBucket):
         ]
         actual = [
             (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('*.txt')])
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[Filter.include('*.txt')])
         ]
         self.assertEqual(expected, actual)
 
@@ -840,7 +842,7 @@ class TestLs(TestCaseWithBucket):
         ]
         actual = [
             (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls(recursive=True, filters=[exclude('*.txt')])
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[Filter.exclude('*.txt')])
         ]
         self.assertEqual(expected, actual)
 
@@ -856,8 +858,10 @@ class TestLs(TestCaseWithBucket):
             ('b/2/test.tsv', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.?sv')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[Filter.include('b/2/test.?sv')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -866,8 +870,10 @@ class TestLs(TestCaseWithBucket):
             ('b/2/test.txt', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.?sv')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[Filter.exclude('b/2/test.?sv')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -885,7 +891,7 @@ class TestLs(TestCaseWithBucket):
         actual = [
             (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
                 recursive=True,
-                filters=[include('b/2/test.[tc]sv')],
+                filters=[Filter.include('b/2/test.[tc]sv')],
             )
         ]
         self.assertEqual(expected, actual)
@@ -897,7 +903,7 @@ class TestLs(TestCaseWithBucket):
         actual = [
             (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
                 recursive=True,
-                filters=[exclude('b/2/test.[tc]sv')],
+                filters=[Filter.exclude('b/2/test.[tc]sv')],
             )
         ]
         self.assertEqual(expected, actual)
@@ -915,7 +921,7 @@ class TestLs(TestCaseWithBucket):
         actual = [
             (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
                 recursive=True,
-                filters=[include('b/2/test.[!ck]sv')],
+                filters=[Filter.include('b/2/test.[!ck]sv')],
             )
         ]
         self.assertEqual(expected, actual)
@@ -928,7 +934,7 @@ class TestLs(TestCaseWithBucket):
         actual = [
             (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
                 recursive=True,
-                filters=[exclude('b/2/test.[!ck]sv')],
+                filters=[Filter.exclude('b/2/test.[!ck]sv')],
             )
         ]
         self.assertEqual(expected, actual)
@@ -942,8 +948,10 @@ class TestLs(TestCaseWithBucket):
             ('b/a.txt', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('b/a.txt')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[Filter.include('b/a.txt')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -951,8 +959,10 @@ class TestLs(TestCaseWithBucket):
             ('b/b.txt', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls(recursive=True, filters=[exclude('b/a.txt')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[Filter.exclude('b/a.txt')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -980,7 +990,7 @@ class TestLs(TestCaseWithBucket):
                 '*.txt',
                 recursive=True,
                 with_wildcard=True,
-                filters=[exclude('*-2.txt')],
+                filters=[Filter.exclude('*-2.txt')],
             )
         ]
         self.assertEqual(expected, actual)
@@ -994,7 +1004,7 @@ class TestLs(TestCaseWithBucket):
                 'b/?-[1234567890].*',
                 recursive=True,
                 with_wildcard=True,
-                filters=[exclude('*-2.*')]
+                filters=[Filter.exclude('*-2.*')]
             )
         ]
         self.assertEqual(expected, actual)
@@ -1012,8 +1022,9 @@ class TestLs(TestCaseWithBucket):
         actual = [
             (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
                 recursive=True,
-                filters=[include('b/*'), exclude('*.txt'),
-                         include('a.txt')],
+                filters=[Filter.include('b/*'),
+                         Filter.exclude('*.txt'),
+                         Filter.include('a.txt')],
             )
         ]
         self.assertEqual(expected, actual)

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -857,8 +857,7 @@ class TestLs(TestCaseWithBucket):
         ]
         actual = [
             (info.file_name, info.size, info.action, folder)
-            for (info,
-                 folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.?sv')])
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.?sv')])
         ]
         self.assertEqual(expected, actual)
 
@@ -868,8 +867,7 @@ class TestLs(TestCaseWithBucket):
         ]
         actual = [
             (info.file_name, info.size, info.action, folder)
-            for (info,
-                 folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.?sv')])
+            for (info, folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.?sv')])
         ]
         self.assertEqual(expected, actual)
 
@@ -974,11 +972,8 @@ class TestLs(TestCaseWithBucket):
             ('b/a.txt', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls('*.txt',
-                                                 recursive=True,
-                                                 with_wildcard=True,
-                                                 filters=[exclude('*-2.txt')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.
+            bucket_ls('*.txt', recursive=True, with_wildcard=True, filters=[exclude('*-2.txt')])
         ]
         self.assertEqual(expected, actual)
 
@@ -987,11 +982,12 @@ class TestLs(TestCaseWithBucket):
             ('b/a-1.txt', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls('b/?-[1234567890].*',
-                                                 recursive=True,
-                                                 with_wildcard=True,
-                                                 filters=[exclude('*-2.*')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                'b/?-[1234567890].*',
+                recursive=True,
+                with_wildcard=True,
+                filters=[exclude('*-2.*')]
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -1006,8 +1002,10 @@ class TestLs(TestCaseWithBucket):
             ('b/a-1.csv', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info, folder) in self.bucket_ls(recursive=True, filters=[include('b/*'), exclude('*.txt'), include('a.txt')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.
+            bucket_ls(recursive=True, filters=[include('b/*'),
+                                               exclude('*.txt'),
+                                               include('a.txt')])
         ]
         self.assertEqual(expected, actual)
 

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -883,9 +883,10 @@ class TestLs(TestCaseWithBucket):
             ('b/2/test.tsv', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info,
-                 folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.[tc]sv')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[include('b/2/test.[tc]sv')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -894,9 +895,10 @@ class TestLs(TestCaseWithBucket):
             ('b/2/test.ksv', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info,
-                 folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.[tc]sv')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[exclude('b/2/test.[tc]sv')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -911,9 +913,10 @@ class TestLs(TestCaseWithBucket):
             ('b/2/test.tsv', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info,
-                 folder) in self.bucket_ls(recursive=True, filters=[include('b/2/test.[!ck]sv')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[include('b/2/test.[!ck]sv')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -923,9 +926,10 @@ class TestLs(TestCaseWithBucket):
             ('b/2/test.ksv', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder)
-            for (info,
-                 folder) in self.bucket_ls(recursive=True, filters=[exclude('b/2/test.[!ck]sv')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[exclude('b/2/test.[!ck]sv')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -972,8 +976,12 @@ class TestLs(TestCaseWithBucket):
             ('b/a.txt', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder) for (info, folder) in self.
-            bucket_ls('*.txt', recursive=True, with_wildcard=True, filters=[exclude('*-2.txt')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                '*.txt',
+                recursive=True,
+                with_wildcard=True,
+                filters=[exclude('*-2.txt')],
+            )
         ]
         self.assertEqual(expected, actual)
 
@@ -1002,10 +1010,11 @@ class TestLs(TestCaseWithBucket):
             ('b/a-1.csv', len(data), 'upload', None),
         ]
         actual = [
-            (info.file_name, info.size, info.action, folder) for (info, folder) in self.
-            bucket_ls(recursive=True, filters=[include('b/*'),
-                                               exclude('*.txt'),
-                                               include('a.txt')])
+            (info.file_name, info.size, info.action, folder) for (info, folder) in self.bucket_ls(
+                recursive=True,
+                filters=[include('b/*'), exclude('*.txt'),
+                         include('a.txt')],
+            )
         ]
         self.assertEqual(expected, actual)
 

--- a/test/unit/filter/__init__.py
+++ b/test/unit/filter/__init__.py
@@ -1,0 +1,10 @@
+######################################################################
+#
+# File: test/unit/filter/__init__.py
+#
+# Copyright 2024 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+from __future__ import annotations

--- a/test/unit/filter/test_filter.py
+++ b/test/unit/filter/test_filter.py
@@ -1,3 +1,14 @@
+######################################################################
+#
+# File: test/unit/filter/test_filter.py
+#
+# Copyright 2024 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+from __future__ import annotations
+
 import pytest
 
 from b2sdk.filter import FilterMatcher, exclude, include

--- a/test/unit/filter/test_filter.py
+++ b/test/unit/filter/test_filter.py
@@ -10,24 +10,31 @@
 from __future__ import annotations
 
 import pytest
+from apiver_deps import Filter
 
-from b2sdk.filter import FilterMatcher, exclude, include
+from b2sdk.filter import FilterMatcher
 
 
 @pytest.mark.parametrize(
     ("filters", "expr", "expected"),
     (
         ([], "a", True),
-        ([exclude("*")], "something", False),
-        ([include("a-*")], "a-", True),
-        ([include("a-*")], "b-", False),
-        ([exclude("*.txt")], "a.txt", False),
-        ([exclude("*.txt")], "a.csv", True),
-        ([exclude("*"), include("*.[ct]sv")], "a.csv", True),
-        ([exclude("*"), include("*.[ct]sv")], "a.tsv", True),
-        ([exclude("*"), include("*.[ct]sv")], "a.ksv", False),
-        ([exclude("*"), include("*.[ct]sv"), exclude("a.csv")], "a.csv", False),
-        ([exclude("*"), include("*.[ct]sv"), exclude("a.csv")], "b.csv", True),
+        ([Filter.exclude("*")], "something", False),
+        ([Filter.include("a-*")], "a-", True),
+        ([Filter.include("a-*")], "b-", False),
+        ([Filter.exclude("*.txt")], "a.txt", False),
+        ([Filter.exclude("*.txt")], "a.csv", True),
+        ([Filter.exclude("*"), Filter.include("*.[ct]sv")], "a.csv", True),
+        ([Filter.exclude("*"), Filter.include("*.[ct]sv")], "a.tsv", True),
+        ([Filter.exclude("*"), Filter.include("*.[ct]sv")], "a.ksv", False),
+        (
+            [Filter.exclude("*"),
+             Filter.include("*.[ct]sv"),
+             Filter.exclude("a.csv")], "a.csv", False
+        ),
+        ([Filter.exclude("*"),
+          Filter.include("*.[ct]sv"),
+          Filter.exclude("a.csv")], "b.csv", True),
     ),
 )
 def test_filter_matcher(filters, expr, expected):

--- a/test/unit/filter/test_filter.py
+++ b/test/unit/filter/test_filter.py
@@ -1,0 +1,23 @@
+import pytest
+
+from b2sdk.filter import FilterMatcher, exclude, include
+
+
+@pytest.mark.parametrize(
+    ("filters", "expr", "expected"),
+    (
+        ([], "a", True),
+        ([exclude("*")], "something", False),
+        ([include("a-*")], "a-", True),
+        ([include("a-*")], "b-", False),
+        ([exclude("*.txt")], "a.txt", False),
+        ([exclude("*.txt")], "a.csv", True),
+        ([exclude("*"), include("*.[ct]sv")], "a.csv", True),
+        ([exclude("*"), include("*.[ct]sv")], "a.tsv", True),
+        ([exclude("*"), include("*.[ct]sv")], "a.ksv", False),
+        ([exclude("*"), include("*.[ct]sv"), exclude("a.csv")], "a.csv", False),
+        ([exclude("*"), include("*.[ct]sv"), exclude("a.csv")], "b.csv", True),
+    ),
+)
+def test_filter_matcher(filters, expr, expected):
+    assert FilterMatcher(filters).match(expr) == expected


### PR DESCRIPTION
- Adds generic filtering machinery at b2sdk/filter.py
- Add filtering capability to Bucket.ls
- This is a prerequisite CLI for adding `--include`/`--exclude` filters for `ls` and `rm` commands