### PR TITLE
allow bigger min_part_size without having to explicitly set recommened_part_size as well

### DIFF
--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -602,10 +602,10 @@ class Bucket(metaclass=B2TraceMeta):
         self,
         local_file,
         file_name,
-        content_type=None,
+        content_type: str | None = None,
         file_info: dict | None = None,
-        sha1_sum=None,
-        min_part_size=None,
+        sha1_sum: str | None = None,
+        min_part_size: int | None = None,
         progress_listener=None,
         encryption: EncryptionSetting | None = None,
         file_retention: FileRetentionSetting | None = None,
@@ -630,10 +630,10 @@ class Bucket(metaclass=B2TraceMeta):
 
         :param str local_file: a path to a file on local disk
         :param str file_name: a file name of the new B2 file
-        :param str,None content_type: the MIME type, or ``None`` to accept the default based on file extension of the B2 file name
-        :param dict,None file_info: a file info to store with the file or ``None`` to not store anything
-        :param str,None sha1_sum: file SHA1 hash or ``None`` to compute it automatically
-        :param int min_part_size: a minimum size of a part
+        :param content_type: the MIME type, or ``None`` to accept the default based on file extension of the B2 file name
+        :param file_info: a file info to store with the file or ``None`` to not store anything
+        :param sha1_sum: file SHA1 hash or ``None`` to compute it automatically
+         a minimum size of a part
         :param b2sdk.v2.AbstractProgressListener,None progress_listener: a progress listener object to use, or ``None`` to not report progress
         :param b2sdk.v2.EncryptionSetting encryption: encryption settings (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
@@ -770,7 +770,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param encryption: encryption settings (``None`` if unknown)
         :param file_retention: file retention setting
         :param legal_hold: legal hold setting
-        :param min_part_size: a minimum size of a part
+         a minimum size of a part
         :param recommended_upload_part_size: the recommended part size to use for uploading local sources
                         or ``None`` to determine automatically
         :param max_part_size: a maximum size of a part
@@ -849,7 +849,7 @@ class Bucket(metaclass=B2TraceMeta):
         file_name,
         content_type=None,
         file_info=None,
-        min_part_size=None,
+        min_part_size: int | None = None,
         progress_listener=None,
         encryption: EncryptionSetting | None = None,
         file_retention: FileRetentionSetting | None = None,
@@ -933,8 +933,8 @@ class Bucket(metaclass=B2TraceMeta):
         encryption: EncryptionSetting | None = None,
         file_retention: FileRetentionSetting | None = None,
         legal_hold: LegalHold | None = None,
-        min_part_size=None,
-        max_part_size=None,
+        min_part_size: int | None = None,
+        max_part_size: int | None = None,
         large_file_sha1=None,
         custom_upload_timestamp: int | None = None,
         cache_control: str | None = None,
@@ -969,8 +969,8 @@ class Bucket(metaclass=B2TraceMeta):
         :param b2sdk.v2.EncryptionSetting encryption: encryption settings (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
         :param bool legal_hold: legal hold setting
-        :param int min_part_size: lower limit of part size for the transfer planner, in bytes
-        :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+         lower limit of part size for the transfer planner, in bytes
+        :param max_part_size: upper limit of part size for the transfer planner, in bytes
         :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         :param int,None custom_upload_timestamp: override object creation date, expressed as a number of milliseconds since epoch
         :param str,None cache_control: an optional cache control setting. Syntax based on the section 14.9 of RFC 2616.
@@ -1021,8 +1021,8 @@ class Bucket(metaclass=B2TraceMeta):
         encryption: EncryptionSetting | None = None,
         file_retention: FileRetentionSetting | None = None,
         legal_hold: LegalHold | None = None,
-        min_part_size=None,
-        max_part_size=None,
+        min_part_size: int | None = None,
+        max_part_size: int | None = None,
         large_file_sha1=None,
         custom_upload_timestamp: int | None = None,
         cache_control: str | None = None,
@@ -1059,8 +1059,8 @@ class Bucket(metaclass=B2TraceMeta):
         :param b2sdk.v2.EncryptionSetting encryption: encryption settings (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
         :param bool legal_hold: legal hold setting
-        :param int min_part_size: lower limit of part size for the transfer planner, in bytes
-        :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param min_part_size: lower limit of part size for the transfer planner, in bytes
+        :param max_part_size: upper limit of part size for the transfer planner, in bytes
         :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         :param int,None custom_upload_timestamp: override object creation date, expressed as a number of milliseconds since epoch
         :param str,None cache_control: an optional cache control setting. Syntax based on the section 14.9 of RFC 2616.
@@ -1112,8 +1112,8 @@ class Bucket(metaclass=B2TraceMeta):
         encryption: EncryptionSetting | None = None,
         file_retention: FileRetentionSetting | None = None,
         legal_hold: LegalHold | None = None,
-        min_part_size=None,
-        max_part_size=None,
+        min_part_size: int | None = None,
+        max_part_size: int | None = None,
         large_file_sha1=None,
         cache_control: str | None = None,
         expires: str | dt.datetime | None = None,
@@ -1163,8 +1163,8 @@ class Bucket(metaclass=B2TraceMeta):
         encryption: EncryptionSetting | None = None,
         file_retention: FileRetentionSetting | None = None,
         legal_hold: LegalHold | None = None,
-        min_part_size=None,
-        max_part_size=None,
+        min_part_size: int | None = None,
+        max_part_size: int | None = None,
         large_file_sha1=None,
         custom_upload_timestamp: int | None = None,
         cache_control: str | None = None,
@@ -1196,8 +1196,8 @@ class Bucket(metaclass=B2TraceMeta):
         :param b2sdk.v2.EncryptionSetting encryption: encryption settings (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
         :param bool legal_hold: legal hold setting
-        :param int min_part_size: lower limit of part size for the transfer planner, in bytes
-        :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param min_part_size: lower limit of part size for the transfer planner, in bytes
+        :param max_part_size: upper limit of part size for the transfer planner, in bytes
         :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         :param int,None custom_upload_timestamp: override object creation date, expressed as a number of milliseconds since epoch
         :param str,None cache_control: an optional cache control setting. Syntax based on the section 14.9 of RFC 2616.
@@ -1350,8 +1350,8 @@ class Bucket(metaclass=B2TraceMeta):
         file_retention: FileRetentionSetting | None = None,
         legal_hold: LegalHold | None = None,
         cache_control: str | None = None,
-        min_part_size=None,
-        max_part_size=None,
+        min_part_size: int | None = None,
+        max_part_size: int | None = None,
         expires: str | dt.datetime | None = None,
         content_disposition: str | None = None,
         content_encoding: str | None = None,

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -633,7 +633,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param content_type: the MIME type, or ``None`` to accept the default based on file extension of the B2 file name
         :param file_info: a file info to store with the file or ``None`` to not store anything
         :param sha1_sum: file SHA1 hash or ``None`` to compute it automatically
-         a minimum size of a part
+        :param min_part_size: lower limit of part size for the transfer planner, in bytes
         :param b2sdk.v2.AbstractProgressListener,None progress_listener: a progress listener object to use, or ``None`` to not report progress
         :param b2sdk.v2.EncryptionSetting encryption: encryption settings (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
@@ -770,10 +770,10 @@ class Bucket(metaclass=B2TraceMeta):
         :param encryption: encryption settings (``None`` if unknown)
         :param file_retention: file retention setting
         :param legal_hold: legal hold setting
-         a minimum size of a part
         :param recommended_upload_part_size: the recommended part size to use for uploading local sources
                         or ``None`` to determine automatically
-        :param max_part_size: a maximum size of a part
+        :param min_part_size: lower limit of part size for the transfer planner, in bytes
+        :param max_part_size: upper limit of part size for the transfer planner, in bytes
         :param large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         :param buffers_count: desired number of buffers allocated, cannot be smaller than 2
         :param buffer_size: size of a single buffer that we pull data to or upload data to B2. If ``None``,
@@ -880,7 +880,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param str file_name: the file name of the new B2 file
         :param str,None content_type: the MIME type, or ``None`` to accept the default based on file extension of the B2 file name
         :param dict,None file_info: a file info to store with the file or ``None`` to not store anything
-        :param int,None min_part_size: the smallest part size to use or ``None`` to determine automatically
+        :param min_part_size: lower limit of part size for the transfer planner, in bytes
         :param b2sdk.v2.AbstractProgressListener,None progress_listener: a progress listener object to use, or ``None`` to not report progress
         :param b2sdk.v2.EncryptionSetting encryption: encryption settings (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
@@ -969,7 +969,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param b2sdk.v2.EncryptionSetting encryption: encryption settings (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
         :param bool legal_hold: legal hold setting
-         lower limit of part size for the transfer planner, in bytes
+        :param min_part_size: lower limit of part size for the transfer planner, in bytes
         :param max_part_size: upper limit of part size for the transfer planner, in bytes
         :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         :param int,None custom_upload_timestamp: override object creation date, expressed as a number of milliseconds since epoch
@@ -1383,6 +1383,8 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting for the new file.
         :param str,None cache_control: an optional cache control setting. Syntax based on the section 14.9 of RFC 2616.
             Example string value: 'public, max-age=86400, s-maxage=3600, no-transform'.
+        :param min_part_size: lower limit of part size for the transfer planner, in bytes
+        :param max_part_size: upper limit of part size for the transfer planner, in bytes
         :param str,datetime.datetime,None expires: an optional cache expiration setting.
             If this argument is a string, its syntax must be based on the section 14.21 of RFC 2616.
             Example string value: 'Thu, 01 Dec 2050 16:00:00 GMT'. If this argument is a datetime,

--- a/b2sdk/transfer/emerge/planner/planner.py
+++ b/b2sdk/transfer/emerge/planner/planner.py
@@ -100,7 +100,7 @@ class EmergePlanner:
         recommended_upload_part_size: int | None = None,
         max_part_size: int | None = None,
     ):
-        # ensure default values are do not break min<=recommended<=max condition,
+        # ensure default values do not break min<=recommended<=max condition,
         # while respecting user input and not auto fixing if something was provided explicitly
         self.min_part_size = min(
             DEFAULT_MIN_PART_SIZE, *_filter_out_none(recommended_upload_part_size, max_part_size)

--- a/changelog.d/+min_part_size.added.md
+++ b/changelog.d/+min_part_size.added.md
@@ -1,0 +1,1 @@
+Allow for `min_part_size` that is greater than default `recommended_part_size` value, without having to explicitly set `recommended_part_size` value.


### PR DESCRIPTION
This will prevent errors in b2 CLI when doing `b2 upload-file bucket test.txt 'test.txt' --minPartSize 100000001`, which currently errors out.