### PR TITLE
Remove setuptools as a runtime dependency

### DIFF
--- a/changelog.d/+setuptools.removed.md
+++ b/changelog.d/+setuptools.removed.md
@@ -1,0 +1,1 @@
+Remove `setuptools` as a runtime dependency; retained for `lint` as `liccheck` still uses `pkg_resources`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "requests<3.0.0,>=2.9.1",
     "tqdm<5.0.0,>=4.5.0",
     "typing-extensions>=4.7.1; python_version < '3.12'",
-    "setuptools>=60.0",
     "packaging>=21.0",
 ]
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ lint = [
     "ruff==0.1.15",
     "pytest==6.2.5",
     "liccheck==0.9.2",
+    "setuptools",
 ]
 test = [
     "coverage==7.2.7",


### PR DESCRIPTION
`setuptools` is not actually used in any runtime code. Only `liccheck` during `lint` uses it for `pkg_resources`, which has long been deprecated (and is more `liccheck`'s problem to migrate away). `liccheck` also does not yet officially support Python 3.12, otherwise I would think they would explicitly specify the `setuptools` dependency themselves.

The only reason why `setuptools` would be present in a runtime environment is for `pkg_resources`, whose functionality has been replaced by `packaging` and the `importlib` suite. Otherwise, `setuptools` pollutes the environment, particularly at the operating system distribution level. Many Python packages have not adopted PEP 517 and still execute `setup.py` directly, functionality that `setuptools` deprecated in 58 and no longer supports after. Multiple `setuptools` cannot exist in the same environment.