### PR TITLE
fix GHA CI by using old macos for old python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,11 @@ jobs:
             python-version: 3.9
         include:
           # Workaround for https://github.com/actions/setup-python/issues/696
-          - os: "macos-12"
+          - os: "macos-13"
             python-version: 3.7
-          - os: "macos-12"
+          - os: "macos-13"
             python-version: 3.8
-          - os: "macos-12"
+          - os: "macos-13"
             python-version: 3.9
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,24 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
         exclude:
           - os: "macos-latest"
-            python-version: "pypy3.9"
-          - os: "ubuntu-latest"
-            python-version: "pypy3.9"
-          - os: "macos-latest"
             python-version: "pypy3.10"
           - os: "windows-latest"
             python-version: "pypy3.10"
+          # Workaround for https://github.com/actions/setup-python/issues/696
+          - os: "macos-latest"
+            python-version: 3.7
+          - os: "macos-latest"
+            python-version: 3.8
+          - os: "macos-latest"
+            python-version: 3.9
+        include:
+          # Workaround for https://github.com/actions/setup-python/issues/696
+          - os: "macos-12"
+            python-version: 3.7
+          - os: "macos-12"
+            python-version: 3.8
+          - os: "macos-12"
+            python-version: 3.9
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
equivalent to https://github.com/Backblaze/B2_Command_Line_Tool/pull/1018