### PR TITLE
Perform exclusions before accessing file/dir

### DIFF
--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -259,8 +259,8 @@ class LocalFolder(AbstractFolder):
                     file_size = local_path.stat().st_size
                 except OSError:
                     # Skip broken symlinks or other inaccessible files
-                    file_mod_time = 0
-                    file_size = 0
+                    file_mod_time = -1
+                    file_size = -1
 
                 local_scan_path = LocalPath(
                     absolute_path=str(local_path.absolute()),

--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -244,7 +244,7 @@ class LocalFolder(AbstractFolder):
         for local_path in local_dir.iterdir():
             name = local_path.name
             relative_file_path = join_b2_path(relative_dir_path, name)
-            
+
             if policies_manager.exclude_all_symlinks and local_path.is_symlink():
                 if reporter is not None:
                     reporter.symlink_skipped(str(local_path))
@@ -261,7 +261,7 @@ class LocalFolder(AbstractFolder):
                     # Skip broken symlinks or other inaccessible files
                     file_mod_time = 0
                     file_size = 0
-                
+
                 local_scan_path = LocalPath(
                     absolute_path=str(local_path.absolute()),
                     relative_path=str(relative_file_path),
@@ -281,7 +281,6 @@ class LocalFolder(AbstractFolder):
             # Skip broken symlinks or other inaccessible files
             if not is_file_readable(str(local_path), reporter):
                 continue
-
 
             if local_path.is_dir():
                 name += '/'

--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -232,7 +232,7 @@ class LocalFolder(AbstractFolder):
         for local_path in sorted(local_dir.iterdir()):
             name = local_path.name
             relative_file_path = join_b2_path(relative_dir_path, name)
-            
+
             if policies_manager.exclude_all_symlinks and local_path.is_symlink():
                 if reporter is not None:
                     reporter.symlink_skipped(str(local_path))
@@ -249,7 +249,8 @@ class LocalFolder(AbstractFolder):
                     continue  # Skip excluded directories
                 # Recurse into directories
                 yield from self._walk_relative_paths(
-                    local_path, relative_file_path, reporter, policies_manager, visited_symlinks)
+                    local_path, relative_file_path, reporter, policies_manager, visited_symlinks
+                )
             else:
                 try:
                     file_mod_time = get_file_mtime(str(local_path))

--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -252,6 +252,8 @@ class LocalFolder(AbstractFolder):
                     local_path, relative_file_path, reporter, policies_manager, visited_symlinks
                 )
             else:
+                if policies_manager.should_exclude_relative_path(relative_file_path):
+                    continue  # Skip excluded files
                 try:
                     file_mod_time = get_file_mtime(str(local_path))
                     file_size = local_path.stat().st_size

--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -229,7 +229,7 @@ class LocalFolder(AbstractFolder):
                 return  # Skip if symlink already visited
             visited_symlinks.add(inode_number)
 
-        for local_path in sorted(local_dir.iterdir(), key=lambda x: x.name):
+        for local_path in sorted(local_dir.iterdir()):
             name = local_path.name
             relative_file_path = join_b2_path(relative_dir_path, name)
             

--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -269,9 +269,6 @@ class LocalFolder(AbstractFolder):
                 if is_file_readable(str(local_path), reporter):
                     yield local_scan_path
 
-                else:
-                    continue  # Skip inaccessible files
-
     @classmethod
     def _handle_non_unicode_file_name(cls, name):
         """

--- a/b2sdk/_internal/scan/policies.py
+++ b/b2sdk/_internal/scan/policies.py
@@ -184,7 +184,7 @@ class ScanPoliciesManager:
                 exclude_uploaded_before, exclude_uploaded_after
             )
 
-    def _should_exclude_relative_path(self, relative_path: str):
+    def should_exclude_relative_path(self, relative_path: str):
         if self._include_file_set.matches(relative_path):
             return False
         return self._exclude_file_set.matches(relative_path)
@@ -197,7 +197,7 @@ class ScanPoliciesManager:
         """
         if local_path.mod_time not in self._include_mod_time_range:
             return True
-        return self._should_exclude_relative_path(local_path.relative_path)
+        return self.should_exclude_relative_path(local_path.relative_path)
 
     def should_exclude_b2_file_version(self, file_version: FileVersion, relative_path: str):
         """
@@ -209,7 +209,7 @@ class ScanPoliciesManager:
             return True
         if file_version.mod_time_millis not in self._include_mod_time_range:
             return True
-        return self._should_exclude_relative_path(relative_path)
+        return self.should_exclude_relative_path(relative_path)
 
     def should_exclude_b2_directory(self, dir_path: str):
         """

--- a/b2sdk/_internal/utils/__init__.py
+++ b/b2sdk/_internal/utils/__init__.py
@@ -252,26 +252,6 @@ def validate_b2_file_name(name):
         raise ValueError("file names segments (between '/') can be at most 250 utf-8 bytes")
 
 
-def is_file_readable(local_path, reporter=None):
-    """
-    Check if the local file has read permissions.
-
-    :param local_path: a file path
-    :type local_path: str
-    :param reporter: reporter object to put errors on
-    :rtype: bool
-    """
-    if not os.path.exists(local_path):
-        if reporter is not None:
-            reporter.local_access_error(local_path)
-        return False
-    elif not os.access(local_path, os.R_OK):
-        if reporter is not None:
-            reporter.local_permission_error(local_path)
-        return False
-    return True
-
-
 def get_file_mtime(local_path):
     """
     Get modification time of a file in milliseconds.

--- a/b2sdk/v1/sync/scan_policies.py
+++ b/b2sdk/v1/sync/scan_policies.py
@@ -133,7 +133,10 @@ class ScanPoliciesManagerWrapper(v2.ScanPoliciesManager):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.scan_policies_manager})"
-
+    
+    def should_exclude_relative_path(self, relative_path: str):
+        self.scan_policies_manager.should_exclude_file(relative_path)
+        
     def should_exclude_local_path(self, local_path: v2.LocalSyncPath):
         if self.scan_policies_manager.should_exclude_file_version(
             _translate_local_path_to_file(local_path).latest_version()

--- a/b2sdk/v1/sync/scan_policies.py
+++ b/b2sdk/v1/sync/scan_policies.py
@@ -133,10 +133,10 @@ class ScanPoliciesManagerWrapper(v2.ScanPoliciesManager):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.scan_policies_manager})"
-    
+
     def should_exclude_relative_path(self, relative_path: str):
         self.scan_policies_manager.should_exclude_file(relative_path)
-        
+
     def should_exclude_local_path(self, local_path: v2.LocalSyncPath):
         if self.scan_policies_manager.should_exclude_file_version(
             _translate_local_path_to_file(local_path).latest_version()

--- a/changelog.d/456.fixed.md
+++ b/changelog.d/456.fixed.md
@@ -1,0 +1,1 @@
+Move exclusions up before reading file/dir in _walk_relative_paths

--- a/changelog.d/456.fixed.md
+++ b/changelog.d/456.fixed.md
@@ -1,1 +1,2 @@
-Move exclusions up before reading file/dir in _walk_relative_paths
+Move exclusions up before reading file/dir in _walk_relative_paths.
+erform exclusion checks before file access attempts. This will prevent unnecessary warnings and IO operations on paths that are not relevant to the operation.

--- a/changelog.d/456.fixed.md
+++ b/changelog.d/456.fixed.md
@@ -1,2 +1,1 @@
-Move exclusions up before reading file/dir in _walk_relative_paths.
-erform exclusion checks before file access attempts. This will prevent unnecessary warnings and IO operations on paths that are not relevant to the operation.
+Move scan filters before a read on filesystem access attempt. This will prevent unnecessary warnings and IO operations on paths that are not relevant to the operation.

--- a/test/unit/scan/test_folder_traversal.py
+++ b/test/unit/scan/test_folder_traversal.py
@@ -709,7 +709,7 @@ class TestFolderTraversal:
         # Restore directory permissions to clean up
         (included_dir / "excluded_file.txt").chmod(0o755)
         excluded_dir.chmod(0o755)
-        
+
         # Check that only included_dir/included_file.txt was return
         assert any('included_file.txt' in path for path in absolute_paths)
 

--- a/test/unit/scan/test_folder_traversal.py
+++ b/test/unit/scan/test_folder_traversal.py
@@ -666,8 +666,10 @@ class TestFolderTraversal:
         included_dir.mkdir()
         (included_dir / "excluded_file.txt").touch()
 
-        # Setup exclusion regex that matches the directory name
-        scan_policy = ScanPoliciesManager(exclude_dir_regexes=[r"excluded_dir$"], exclude_file_regexes=[r'.*excluded_file.txt'])
+        # Setup exclusion regex that matches the excluded directory/file name
+        scan_policy = ScanPoliciesManager(
+            exclude_dir_regexes=[r"excluded_dir$"], exclude_file_regexes=[r'.*excluded_file.txt']
+        )
         reporter = ProgressReport(sys.stdout, False)
 
         # Patch os.access to monitor if it is called on the excluded file
@@ -675,17 +677,17 @@ class TestFolderTraversal:
             folder = LocalFolder(str(tmp_path))
             list(folder.all_files(reporter=reporter, policies_manager=scan_policy))
 
-            # Verify os.access was not called for the excluded file
+            # Verify os.access was not called for the excluded directory/file
             mocked_access.assert_not_called()
 
         reporter.close()
 
-    def test_excluded_folder_without_permissions(self, tmp_path):
+    def test_excluded_without_permissions(self, tmp_path):
         """Test that a excluded directory/file without permissions is not processed and no warning is issued."""
         excluded_dir = tmp_path / "excluded_dir"
         excluded_dir.mkdir()
         (excluded_dir / "file.txt").touch()
-        
+
         included_dir = tmp_path / "included_dir"
         included_dir.mkdir()
         (included_dir / "excluded_file.txt").touch()
@@ -695,7 +697,9 @@ class TestFolderTraversal:
         (included_dir / "excluded_file.txt").chmod(0o000)
         excluded_dir.chmod(0o000)
 
-        scan_policy = ScanPoliciesManager(exclude_dir_regexes=[r"excluded_dir$"], exclude_file_regexes=[r'.*excluded_file.txt'])
+        scan_policy = ScanPoliciesManager(
+            exclude_dir_regexes=[r"excluded_dir$"], exclude_file_regexes=[r'.*excluded_file.txt']
+        )
         reporter = ProgressReport(sys.stdout, False)
 
         folder = LocalFolder(str(tmp_path))
@@ -710,9 +714,11 @@ class TestFolderTraversal:
         assert absolute_paths == [f"{tmp_path}/included_dir/included_file.txt"]
 
         # Check that no access warnings are issued for the excluded directory/file
-        assert not any(re.match(
-            r"WARNING: .*excluded_.* could not be accessed \(no permissions to read\?\)",
-            warning,
-            ) for warning in reporter.warnings), "Access warning was issued for the excluded directory/file"
+        assert not any(
+            re.match(
+                r"WARNING: .*excluded_.* could not be accessed \(no permissions to read\?\)",
+                warning,
+            ) for warning in reporter.warnings
+        ), "Access warning was issued for the excluded directory/file"
 
         reporter.close()

--- a/test/unit/scan/test_folder_traversal.py
+++ b/test/unit/scan/test_folder_traversal.py
@@ -709,9 +709,9 @@ class TestFolderTraversal:
         # Restore directory permissions to clean up
         (included_dir / "excluded_file.txt").chmod(0o755)
         excluded_dir.chmod(0o755)
-        print(reporter.warnings)
+        
         # Check that only included_dir/included_file.txt was return
-        assert absolute_paths == [f"{tmp_path}/included_dir/included_file.txt"]
+        assert any('included_file.txt' in path for path in absolute_paths)
 
         # Check that no access warnings are issued for the excluded directory/file
         assert not any(

--- a/test/unit/v0/test_sync.py
+++ b/test/unit/v0/test_sync.py
@@ -66,10 +66,10 @@ class TestFolder(TestSync):
 
     NAMES = [
         '.dot_file',
-        'hello.',
         os.path.join('hello', 'a', '1'),
         os.path.join('hello', 'a', '2'),
         os.path.join('hello', 'b'),
+        'hello.',
         'hello0',
         os.path.join('inner', 'a.bin'),
         os.path.join('inner', 'a.txt'),
@@ -106,10 +106,10 @@ class TestFolder(TestSync):
     def test_exclusions(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/a/1',
             'hello/a/2',
             'hello/b',
+            'hello.',
             'hello0',
             'inner/a.txt',
             'inner/b.txt',
@@ -129,10 +129,10 @@ class TestFolder(TestSync):
     def test_exclusions_inclusions(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/a/1',
             'hello/a/2',
             'hello/b',
+            'hello.',
             'hello0',
             'inner/a.bin',
             'inner/a.txt',
@@ -151,8 +151,8 @@ class TestFolder(TestSync):
     def test_exclude_matches_prefix(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/b',
+            'hello.',
             'hello0',
             'inner/b.bin',
             'inner/b.txt',
@@ -204,10 +204,10 @@ class TestFolder(TestSync):
     def test_exclusion_with_exact_match(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/a/1',
             'hello/a/2',
             'hello/b',
+            'hello.',
             'inner/a.bin',
             'inner/a.txt',
             'inner/b.bin',

--- a/test/unit/v1/test_sync.py
+++ b/test/unit/v1/test_sync.py
@@ -69,10 +69,10 @@ class TestFolder(TestSync):
 
     NAMES = [
         '.dot_file',
-        'hello.',
         os.path.join('hello', 'a', '1'),
         os.path.join('hello', 'a', '2'),
         os.path.join('hello', 'b'),
+        'hello.',
         'hello0',
         os.path.join('inner', 'a.bin'),
         os.path.join('inner', 'a.txt'),
@@ -109,10 +109,10 @@ class TestFolder(TestSync):
     def test_exclusions(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/a/1',
             'hello/a/2',
             'hello/b',
+            'hello.',
             'hello0',
             'inner/a.txt',
             'inner/b.txt',
@@ -132,10 +132,10 @@ class TestFolder(TestSync):
     def test_exclusions_inclusions(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/a/1',
             'hello/a/2',
             'hello/b',
+            'hello.',
             'hello0',
             'inner/a.bin',
             'inner/a.txt',
@@ -154,8 +154,8 @@ class TestFolder(TestSync):
     def test_exclude_matches_prefix(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/b',
+            'hello.',
             'hello0',
             'inner/b.bin',
             'inner/b.txt',
@@ -207,10 +207,10 @@ class TestFolder(TestSync):
     def test_exclusion_with_exact_match(self):
         expected_list = [
             '.dot_file',
-            'hello.',
             'hello/a/1',
             'hello/a/2',
             'hello/b',
+            'hello.',
             'inner/a.bin',
             'inner/a.txt',
             'inner/b.bin',


### PR DESCRIPTION
resolves #496

The method `_walk_relative_paths` attempts to yield a File object for each file under a folder, applying exclusion policies only after accessing the file or directory attributes.

This PR is a refactoring of `_walk_relative_paths`, ensuring that excluded paths are skipped.