### PR TITLE
pytest: switch hook from path to collection_path

### DIFF
--- a/changelog.d/+pytest_collection_path.changed.md
+++ b/changelog.d/+pytest_collection_path.changed.md
@@ -1,0 +1,1 @@
+Switch a pytest hook from path to collection_path.

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -64,13 +64,12 @@ def pytest_report_header(config):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     """Ignore all tests from subfolders for different apiver."""
-    path = str(path)
     ver = config.getoption('--api')
     other_versions = [v for v in API_VERSIONS if v != ver]
     for other_version in other_versions:
-        if other_version + os.sep in path:
+        if other_version in collection_path.parts:
             return True
     return False
 


### PR DESCRIPTION
solves PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (collection_path: pathlib.Path) https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path