### PR TITLE
Suppress BrokenPipeError when saving downloaded content to stdout

### DIFF
--- a/b2sdk/_internal/transfer/inbound/downloaded_file.py
+++ b/b2sdk/_internal/transfer/inbound/downloaded_file.py
@@ -274,6 +274,12 @@ class DownloadedFile:
             try:
                 with context as file:
                     return self.save(file, allow_seeking=allow_seeking)
+            except BrokenPipeError as ex:
+                if is_stdout:
+                    # Output was likely piped through a command such as head. Just ignore the error
+                    return
+                else:
+                    raise ex
             finally:
                 if not is_stdout:
                     set_file_mtime(path_, self.download_version.mod_time_millis)

--- a/changelog.d/534.fixed.md
+++ b/changelog.d/534.fixed.md
@@ -1,0 +1,1 @@
+Suppress BrokenPipeError when saving downloaded content to stdout.


### PR DESCRIPTION
Fixes https://github.com/Backblaze/B2_Command_Line_Tool/issues/1071

Lint and tests pass.