### PR TITLE
Run CLI tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,16 @@ jobs:
         run: uv run --directory ./B2_Command_Line_Tool nox -vs integration -p ${{ matrix.python-version }} -- -m "not require_secrets"
       - name: Run CLI integration tests (with secrets)
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}
-        run: uv run --directory ./B2_Command_Line_Tool nox -vs integration -p ${{ matrix.python-version }} -- -m "require_secrets" --cleanup
+        working-directory: B2_Command_Line_Tool
+        run: |
+          .nox/integration-3-14/bin/python -m pytest \
+            test/integration \
+            -n 1 \
+            --log-level INFO \
+            -W ignore::DeprecationWarning:rst2ansi.visitor: \
+            -m "require_secrets" \
+            --cleanup \
+            --sut .nox/integration-3-14/bin/b2v4
   doc:
     timeout-minutes: 30
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,14 +195,16 @@ jobs:
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}
         working-directory: B2_Command_Line_Tool
         run: |
-          .nox/integration-3-14/bin/python -m pytest \
+          export VIRTUAL_ENV="$PWD/.nox/integration-3-14"
+          export PATH="$VIRTUAL_ENV/bin:$PATH"
+          python -m pytest \
             test/integration \
             -n 1 \
             --log-level INFO \
             -W ignore::DeprecationWarning:rst2ansi.visitor: \
             -m "require_secrets" \
             --cleanup \
-            --sut .nox/integration-3-14/bin/b2v4
+            --sut "$VIRTUAL_ENV/bin/b2v4"
   doc:
     timeout-minutes: 30
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,61 @@ jobs:
       - name: Run integration tests
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: uv run nox -vs integration -- --dont-cleanup-old-buckets -v
+  cli-compat:
+    timeout-minutes: 90
+    needs: cleanup_buckets
+    env:
+      B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}
+      B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}
+      INSTALL_SDK_FROM: ../b2-sdk-python
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.14"
+          - os: macos-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.12"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: b2-sdk-python
+      - uses: actions/checkout@v4
+        with:
+          repository: Backblaze/B2_Command_Line_Tool
+          path: B2_Command_Line_Tool
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Install test binary dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install zsh fish
+          sudo chmod -R 755 /usr/share/zsh/vendor-completions /usr/share/zsh
+      - name: Install test binary dependencies (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: brew install fish
+      - name: Install dependencies
+        run: uv sync --directory ./B2_Command_Line_Tool --locked --group nox
+      - name: Run CLI unit tests
+        run: uv run --directory ./B2_Command_Line_Tool nox -vs unit -p ${{ matrix.python-version }}
+      - name: Run CLI integration tests (without secrets)
+        run: uv run --directory ./B2_Command_Line_Tool nox -vs integration -p ${{ matrix.python-version }} -- -m "not require_secrets"
+      - name: Run CLI integration tests (with secrets)
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}
+        run: uv run --directory ./B2_Command_Line_Tool nox -vs integration -p ${{ matrix.python-version }} -- -m "require_secrets" --cleanup
   doc:
     timeout-minutes: 30
     needs: build

--- a/changelog.d/+cli-compat.infrastructure.md
+++ b/changelog.d/+cli-compat.infrastructure.md
@@ -1,0 +1,1 @@
+Run B2 CLI unit tests and integration tests in CI against the SDK checkout.


### PR DESCRIPTION
Supersedes #260.

This revives the original idea on top of the current CI layout:
- add a dedicated `cli-compat` workflow job that checks out `Backblaze/B2_Command_Line_Tool`
- install this SDK checkout into the CLI test environment via `INSTALL_SDK_FROM`
- run CLI unit tests across a focused compatibility matrix
- run non-secret CLI integration tests across that matrix
- run secret-backed CLI integration on a single Linux / Python 3.14 lane to keep CI load bounded

Validation run locally:
- `uv run nox -vs towncrier_check`
- CLI unit tests against this checkout on Python 3.12
- CLI non-secret integration tests against this checkout on Python 3.12 (`b2v3` and `b2v4`)
