### PR TITLE
Add Read the Docs build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.14"
+  apt_packages:
+    - graphviz
+    - plantuml
+
+sphinx:
+  configuration: doc/source/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - doc

--- a/changelog.d/+readthedocs-config.infrastructure.md
+++ b/changelog.d/+readthedocs-config.infrastructure.md
@@ -1,0 +1,1 @@
+Add a checked-in Read the Docs build configuration so docs builds install the required doc dependencies and system packages.


### PR DESCRIPTION
## Summary
- add a checked-in Read the Docs config for this repository
- install the system packages required by the Sphinx docs build on RTD
- install the Python doc dependency group with `uv` so RTD builds match local/CI docs builds

## Why
The repo currently builds docs in CI, but CD does not publish docs and the repository does not include a `.readthedocs.yaml` file for RTD to consume. The docs build also requires `graphviz` and `plantuml`, which are installed in GitHub Actions but were not declared for RTD.

## Verification
- `uv run nox --non-interactive -vs doc`